### PR TITLE
Phase 3: define shared common types in common crate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1008,6 +1008,11 @@ dependencies = [
 [[package]]
 name = "gig-log-common"
 version = "0.1.0"
+dependencies = [
+ "chrono",
+ "serde",
+ "uuid",
+]
 
 [[package]]
 name = "gig-log-dev-tools"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1011,6 +1011,7 @@ version = "0.1.0"
 dependencies = [
  "chrono",
  "serde",
+ "serde_json",
  "uuid",
 ]
 

--- a/common/Cargo.toml
+++ b/common/Cargo.toml
@@ -6,4 +6,5 @@ edition = "2024"
 [dependencies]
 chrono = { version = "0.4.44", features = ["serde"] }
 serde = { version = "1.0.228", features = ["derive"] }
+serde_json = "1.0.149"
 uuid = { version = "1.21.0", features = ["serde"] }

--- a/common/Cargo.toml
+++ b/common/Cargo.toml
@@ -4,3 +4,6 @@ version = "0.1.0"
 edition = "2024"
 
 [dependencies]
+chrono = { version = "0.4.44", features = ["serde"] }
+serde = { version = "1.0.228", features = ["derive"] }
+uuid = { version = "1.21.0", features = ["serde"] }

--- a/common/src/lib.rs
+++ b/common/src/lib.rs
@@ -1,0 +1,1 @@
+pub mod models;

--- a/common/src/models/appearance.rs
+++ b/common/src/models/appearance.rs
@@ -1,0 +1,58 @@
+use chrono::{DateTime, Utc};
+use serde::{Deserialize, Serialize};
+use serde_json::Value;
+use uuid::Uuid;
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+#[serde(rename_all = "snake_case")]
+pub enum PaletteType {
+    Preset,
+    Custom,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+#[serde(rename_all = "snake_case")]
+pub enum PresetPalette {
+    Catppuccin,
+    TokyoNight,
+    Everforest,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ColorPalette {
+    pub id: Uuid,
+    pub user_id: Uuid,
+    pub name: String,
+    pub seed_colors: Vec<String>,
+    pub generated_tokens: Value,
+    pub created_at: DateTime<Utc>,
+    pub updated_at: DateTime<Utc>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct AppearancePreferences {
+    pub id: Uuid,
+    pub user_id: Uuid,
+    pub active_palette_type: PaletteType,
+    pub active_preset_palette: Option<PresetPalette>,
+    pub active_custom_palette_id: Option<Uuid>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct CreatePaletteRequest {
+    pub name: String,
+    pub seed_colors: Vec<String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct UpdatePaletteRequest {
+    pub name: Option<String>,
+    pub seed_colors: Option<Vec<String>>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct UpdateActivePaletteRequest {
+    pub active_palette_type: PaletteType,
+    pub active_preset_palette: Option<PresetPalette>,
+    pub active_custom_palette_id: Option<Uuid>,
+}

--- a/common/src/models/appearance.rs
+++ b/common/src/models/appearance.rs
@@ -11,7 +11,7 @@ pub enum PaletteType {
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
-#[serde(rename_all = "snake_case")]
+#[serde(rename_all = "kebab-case")]
 pub enum PresetPalette {
     Catppuccin,
     TokyoNight,

--- a/common/src/models/company.rs
+++ b/common/src/models/company.rs
@@ -1,0 +1,28 @@
+use chrono::{DateTime, Utc};
+use serde::{Deserialize, Serialize};
+use uuid::Uuid;
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct Company {
+    pub id: Uuid,
+    pub user_id: Uuid,
+    pub name: String,
+    pub requires_tax_withholdings: bool,
+    pub tax_withholding_rate: Option<f64>,
+    pub created_at: DateTime<Utc>,
+    pub updated_at: DateTime<Utc>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct CreateCompanyRequest {
+    pub name: String,
+    pub requires_tax_withholdings: bool,
+    pub tax_withholding_rate: Option<f64>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct UpdateCompanyRequest {
+    pub name: Option<String>,
+    pub requires_tax_withholdings: Option<bool>,
+    pub tax_withholding_rate: Option<f64>,
+}

--- a/common/src/models/error.rs
+++ b/common/src/models/error.rs
@@ -1,0 +1,14 @@
+use serde::{Deserialize, Serialize};
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ValidationError {
+    pub field: Option<String>,
+    pub message: String,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ApiError {
+    pub status_code: u16,
+    pub message: String,
+    pub errors: Option<Vec<ValidationError>>,
+}

--- a/common/src/models/job.rs
+++ b/common/src/models/job.rs
@@ -1,0 +1,43 @@
+use chrono::{DateTime, Utc};
+use serde::{Deserialize, Serialize};
+use uuid::Uuid;
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+#[serde(rename_all = "snake_case")]
+pub enum PaymentType {
+    Hourly,
+    Payouts,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct Job {
+    pub id: Uuid,
+    pub company_id: Uuid,
+    pub user_id: Uuid,
+    pub title: String,
+    pub payment_type: PaymentType,
+    pub hourly_rate: Option<f64>,
+    pub number_of_payouts: Option<i32>,
+    pub payout_amount: Option<f64>,
+    pub created_at: DateTime<Utc>,
+    pub updated_at: DateTime<Utc>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct CreateJobRequest {
+    pub company_id: Uuid,
+    pub title: String,
+    pub payment_type: PaymentType,
+    pub hourly_rate: Option<f64>,
+    pub number_of_payouts: Option<i32>,
+    pub payout_amount: Option<f64>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct UpdateJobRequest {
+    pub title: Option<String>,
+    pub payment_type: Option<PaymentType>,
+    pub hourly_rate: Option<f64>,
+    pub number_of_payouts: Option<i32>,
+    pub payout_amount: Option<f64>,
+}

--- a/common/src/models/mod.rs
+++ b/common/src/models/mod.rs
@@ -1,0 +1,1 @@
+pub mod user;

--- a/common/src/models/mod.rs
+++ b/common/src/models/mod.rs
@@ -1,3 +1,4 @@
+pub mod appearance;
 pub mod company;
 pub mod job;
 pub mod payment;

--- a/common/src/models/mod.rs
+++ b/common/src/models/mod.rs
@@ -1,3 +1,4 @@
 pub mod company;
 pub mod job;
+pub mod payment;
 pub mod user;

--- a/common/src/models/mod.rs
+++ b/common/src/models/mod.rs
@@ -1,2 +1,3 @@
 pub mod company;
+pub mod job;
 pub mod user;

--- a/common/src/models/mod.rs
+++ b/common/src/models/mod.rs
@@ -1,5 +1,6 @@
 pub mod appearance;
 pub mod company;
+pub mod error;
 pub mod job;
 pub mod payment;
 pub mod user;

--- a/common/src/models/mod.rs
+++ b/common/src/models/mod.rs
@@ -1,1 +1,2 @@
+pub mod company;
 pub mod user;

--- a/common/src/models/mod.rs
+++ b/common/src/models/mod.rs
@@ -2,3 +2,4 @@ pub mod company;
 pub mod job;
 pub mod payment;
 pub mod user;
+pub mod work_session;

--- a/common/src/models/payment.rs
+++ b/common/src/models/payment.rs
@@ -1,0 +1,50 @@
+use chrono::{DateTime, NaiveDate, Utc};
+use serde::{Deserialize, Serialize};
+use uuid::Uuid;
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+#[serde(rename_all = "snake_case")]
+pub enum PayoutType {
+    Paypal,
+    Cash,
+    Check,
+    Zelle,
+    Venmo,
+    DirectDeposit,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct Payment {
+    pub id: Uuid,
+    pub user_id: Uuid,
+    pub company_id: Uuid,
+    pub total: f64,
+    pub payout_type: PayoutType,
+    pub expected_payout_date: Option<NaiveDate>,
+    pub transfer_initiated: bool,
+    pub payment_received: bool,
+    pub tax_withholdings_covered: bool,
+    pub created_at: DateTime<Utc>,
+    pub updated_at: DateTime<Utc>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct CreatePaymentRequest {
+    pub company_id: Uuid,
+    pub total: f64,
+    pub payout_type: PayoutType,
+    pub expected_payout_date: Option<NaiveDate>,
+    pub transfer_initiated: bool,
+    pub payment_received: bool,
+    pub tax_withholdings_covered: bool,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct UpdatePaymentRequest {
+    pub total: Option<f64>,
+    pub payout_type: Option<PayoutType>,
+    pub expected_payout_date: Option<NaiveDate>,
+    pub transfer_initiated: Option<bool>,
+    pub payment_received: Option<bool>,
+    pub tax_withholdings_covered: Option<bool>,
+}

--- a/common/src/models/user.rs
+++ b/common/src/models/user.rs
@@ -1,0 +1,58 @@
+use chrono::{DateTime, Utc};
+use serde::{Deserialize, Serialize};
+use uuid::Uuid;
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct User {
+    pub id: Uuid,
+    pub first_name: String,
+    pub last_name: String,
+    pub email: String,
+    pub email_confirmed: bool,
+    pub created_at: DateTime<Utc>,
+    pub updated_at: DateTime<Utc>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct SignUpRequest {
+    pub first_name: String,
+    pub last_name: String,
+    pub email: String,
+    pub password: String,
+    pub confirm_password: String,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct LogInRequest {
+    pub email: String,
+    pub password: String,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ChangePasswordRequest {
+    pub current_password: String,
+    pub new_password: String,
+    pub confirm_new_password: String,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct RequestEmailChangeRequest {
+    pub new_email: String,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ForgotPasswordRequest {
+    pub email: String,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct SetPasswordRequest {
+    pub code: String,
+    pub new_password: String,
+    pub confirm_new_password: String,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct VerifyForgotPasswordRequest {
+    pub code: String,
+}

--- a/common/src/models/work_session.rs
+++ b/common/src/models/work_session.rs
@@ -1,0 +1,26 @@
+use chrono::{DateTime, Utc};
+use serde::{Deserialize, Serialize};
+use uuid::Uuid;
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+#[serde(rename_all = "snake_case")]
+pub enum WorkSessionStatus {
+    Active,
+    Paused,
+    Completed,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct WorkSession {
+    pub id: Uuid,
+    pub user_id: Uuid,
+    pub job_id: Uuid,
+    pub start_time: DateTime<Utc>,
+    pub end_time: Option<DateTime<Utc>>,
+    pub is_running: bool,
+    pub accumulated_paused_duration: i64,
+    pub paused_at: Option<DateTime<Utc>>,
+    pub time_reported: Option<i64>,
+    pub created_at: DateTime<Utc>,
+    pub updated_at: DateTime<Utc>,
+}

--- a/justfile
+++ b/justfile
@@ -62,6 +62,16 @@ web-add *args:
 web-remove *args:
     cd web && cargo remove {{args}}
 
+# Common
+common-build:
+	cargo build -p gig-log-common
+
+common-release:
+	cargo build --release -p gig-log-common
+
+common-add *args:
+	cd common && cargo add {{args}}
+
 # Development
 dev-tools *args:
     cargo run -p gig-log-dev-tools -- {{args}}


### PR DESCRIPTION
## Summary
- Add WASM-safe shared dependencies to `gig-log-common` and export a `models` module from the common crate.
- Define shared user, company, job, payment, work session, appearance, and API error models in `common/src/models/*` for API/frontend reuse.
- Add `just` commands for common crate workflows (`common-build`, `common-release`, `common-add`) and align `PresetPalette` serde naming with existing wire values (`kebab-case`).

## Testing
- `cargo check -p gig-log-common`
- `cargo test -p gig-log-common`
- `cargo check -p gig-log-frontend`
- `cargo check -p gig-log-frontend --target wasm32-unknown-unknown`