### PR TITLE
Update dev TUI auto-clear behavior for batch runs

### DIFF
--- a/dev-tools/src/dev/mod.rs
+++ b/dev-tools/src/dev/mod.rs
@@ -193,6 +193,8 @@ async fn run_orchestrator(
             continue;
         }
 
+        let _ = tui_tx.send(TuiEvent::ClearLogs).await;
+
         system_log(
             &system_log_tx,
             format!("Executing batch: {}", describe_batch(batch)),

--- a/dev-tools/src/dev/tui.rs
+++ b/dev-tools/src/dev/tui.rs
@@ -16,6 +16,7 @@ use super::ui::{self, AppState};
 
 pub enum TuiEvent {
     Log(LogEntry),
+    ClearLogs,
     ServiceStarted(Service),
     ServiceExited(Service),
 }
@@ -156,6 +157,10 @@ fn handle_key_event(
             state.follow = true;
             false
         }
+        (KeyCode::Char('x'), _) => {
+            state.auto_clear = !state.auto_clear;
+            false
+        }
         (KeyCode::Char('a'), _) => {
             state.filter = None;
             state.scroll_offset = 0;
@@ -214,6 +219,13 @@ fn apply_tui_event(log_store: &mut LogStore, state: &mut AppState, event: TuiEve
         TuiEvent::Log(entry) => {
             log_store.push(entry);
         }
+        TuiEvent::ClearLogs => {
+            if state.auto_clear {
+                log_store.clear();
+                state.scroll_offset = 0;
+                state.follow = true;
+            }
+        }
         TuiEvent::ServiceStarted(service) => match service {
             Service::Api => state.services_running[0] = true,
             Service::Web => state.services_running[1] = true,
@@ -230,5 +242,73 @@ fn apply_tui_event(log_store: &mut LogStore, state: &mut AppState, event: TuiEve
             Service::Docs => state.services_running[4] = false,
             Service::System => state.services_running[5] = false,
         },
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{TuiEvent, apply_tui_event, handle_key_event};
+    use crate::dev::log_store::{LogEntry, LogStore, Service};
+    use crate::dev::ui::AppState;
+    use crossterm::event::{KeyCode, KeyModifiers};
+
+    fn sample_entry() -> LogEntry {
+        LogEntry {
+            service: Service::Api,
+            line: "sample".to_string(),
+        }
+    }
+
+    #[test]
+    fn clear_logs_clears_store_when_auto_clear_enabled() {
+        let mut log_store = LogStore::new();
+        log_store.push(sample_entry());
+
+        let mut state = AppState::new();
+        state.follow = false;
+        state.scroll_offset = 7;
+        state.auto_clear = true;
+
+        apply_tui_event(&mut log_store, &mut state, TuiEvent::ClearLogs);
+
+        assert!(log_store.filtered(None).is_empty());
+        assert_eq!(state.scroll_offset, 0);
+        assert!(state.follow);
+    }
+
+    #[test]
+    fn clear_logs_is_noop_when_auto_clear_disabled() {
+        let mut log_store = LogStore::new();
+        log_store.push(sample_entry());
+
+        let mut state = AppState::new();
+        state.follow = false;
+        state.scroll_offset = 7;
+        state.auto_clear = false;
+
+        apply_tui_event(&mut log_store, &mut state, TuiEvent::ClearLogs);
+
+        assert_eq!(log_store.filtered(None).len(), 1);
+        assert_eq!(state.scroll_offset, 7);
+        assert!(!state.follow);
+    }
+
+    #[test]
+    fn x_key_toggles_auto_clear() {
+        let mut log_store = LogStore::new();
+        let mut state = AppState::new();
+        assert!(state.auto_clear);
+
+        let should_quit = handle_key_event(
+            &mut log_store,
+            &mut state,
+            KeyCode::Char('x'),
+            KeyModifiers::NONE,
+            0,
+            1,
+        );
+
+        assert!(!should_quit);
+        assert!(!state.auto_clear);
     }
 }

--- a/dev-tools/src/dev/ui.rs
+++ b/dev-tools/src/dev/ui.rs
@@ -21,6 +21,7 @@ pub struct AppState {
     pub follow: bool,
     pub pending_g: bool,
     pub services_running: [bool; 6], // [api, web, common, dev-tools, docs, system]
+    pub auto_clear: bool,
 }
 
 impl AppState {
@@ -31,6 +32,7 @@ impl AppState {
             follow: true,
             pending_g: false,
             services_running: [false; 6],
+            auto_clear: true,
         }
     }
 }
@@ -253,6 +255,8 @@ fn render_footer(frame: &mut Frame, area: Rect, state: &AppState) {
         Some(Service::System) => "system",
     };
 
+    let auto_clear_label = if state.auto_clear { "on" } else { "off" };
+
     let line = Line::from(vec![
         Span::styled("  Filter: ", Style::default().fg(Color::DarkGray)),
         Span::styled(
@@ -261,8 +265,15 @@ fn render_footer(frame: &mut Frame, area: Rect, state: &AppState) {
                 .fg(Color::White)
                 .add_modifier(Modifier::BOLD),
         ),
+        Span::styled("  Auto-clear: ", Style::default().fg(Color::DarkGray)),
         Span::styled(
-            "  |  c:clear  1:api  2:web  3:common  4:dev-tools  5:docs  6:system  a:all  j/k:scroll  gg:top  G:bottom  ^u/^d:page",
+            auto_clear_label,
+            Style::default()
+                .fg(Color::White)
+                .add_modifier(Modifier::BOLD),
+        ),
+        Span::styled(
+            "  |  c:clear  x:auto-clear  1:api  2:web  3:common  4:dev-tools  5:docs  6:system  a:all  j/k:scroll  gg:top  G:bottom  ^u/^d:page",
             Style::default().fg(Color::DarkGray),
         ),
     ]);


### PR DESCRIPTION
## Summary
- Add a new `ClearLogs` TUI event dispatched before each orchestrator batch so logs reset between batches.
- Add an `auto_clear` toggle to TUI state (default on), bind it to `x`, and display the current on/off status in the footer.
- Add unit tests covering `ClearLogs` behavior (enabled/disabled) and `x` key toggle handling.

## Testing
- `cargo test -p gig-log-dev-tools`