### PR TITLE
Improve logging parity across API, web, and dev tooling

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -21,6 +21,8 @@ RESEND_FROM_EMAIL=noreply@yourdomain.com
 AUTH_CODE_EXPIRY_SECONDS=600
 
 # Logging
+# HTTP request/response body logging is enabled automatically in development
+# and disabled automatically in production.
 LOG_LEVEL=debug
 LOG_VERBOSE=true
 LOG_HTTP_MAX_BODY_BYTES=16384

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -517,6 +517,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b05b61dc5112cbb17e4b6cd61790d9845d13888356391624cbe7e41efeac1e75"
 
 [[package]]
+name = "colorized"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "739281952453521b532f476b5f8b77c4b16d5ab2a248466c8dc153b3f85d6564"
+
+[[package]]
 name = "combine"
 version = "4.6.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1444,9 +1450,11 @@ dependencies = [
  "axum",
  "axum-extra",
  "chrono",
+ "colorized",
  "dotenvy",
  "gig-log-common",
  "jsonwebtoken",
+ "log",
  "rand 0.10.0",
  "reqwest",
  "serde",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1473,6 +1473,7 @@ name = "gig-log-common"
 version = "0.1.0"
 dependencies = [
  "chrono",
+ "log",
  "serde",
  "serde_json",
  "uuid",
@@ -1485,6 +1486,7 @@ version = "0.1.0"
 dependencies = [
  "ansi-to-tui",
  "anyhow",
+ "axum",
  "clap",
  "crossterm 0.28.1",
  "dialoguer",
@@ -1507,7 +1509,11 @@ name = "gig-log-frontend"
 version = "0.1.0"
 dependencies = [
  "gig-log-common",
+ "gloo-net",
  "leptos",
+ "log",
+ "serde",
+ "wasm-bindgen-futures",
 ]
 
 [[package]]

--- a/api/Cargo.toml
+++ b/api/Cargo.toml
@@ -9,11 +9,13 @@ argon2 = "0.5.3"
 axum = "0.8.8"
 axum-extra = { version = "0.12.5", features = ["cookie"] }
 chrono = { version = "0.4.44", features = ["serde"] }
+colorized = "1.0.0"
 dotenvy = "0.15.7"
 gig-log-common = { path = "../common", features = ["validation"] }
 jsonwebtoken = { version = "10.3.0", default-features = false, features = [
     "rust_crypto",
 ] }
+log = "0.4.28"
 rand = "0.10.0"
 reqwest = { version = "0.13.2", features = ["json"] }
 serde = { version = "1.0.228", features = ["derive"] }

--- a/api/src/auth/jwt.rs
+++ b/api/src/auth/jwt.rs
@@ -1,5 +1,6 @@
 use chrono::Utc;
 use jsonwebtoken::{DecodingKey, EncodingKey, Header, TokenData, Validation, decode, encode};
+use log::error;
 use serde::{Deserialize, Serialize};
 use uuid::Uuid;
 
@@ -31,7 +32,8 @@ impl JwtUtil {
             &claims,
             &EncodingKey::from_secret(config.jwt_secret.as_bytes()),
         )
-        .map_err(|_| {
+        .map_err(|error| {
+            error!("Failed to generate access token: {}", error);
             ApiErrorResponse::InternalServerError("Failed to generate access token".to_string())
         })
     }
@@ -51,7 +53,8 @@ impl JwtUtil {
             &claims,
             &EncodingKey::from_secret(config.jwt_secret.as_bytes()),
         )
-        .map_err(|_| {
+        .map_err(|error| {
+            error!("Failed to generate refresh token: {}", error);
             ApiErrorResponse::InternalServerError("Failed to generate refresh token".to_string())
         })
     }
@@ -65,6 +68,9 @@ impl JwtUtil {
             &DecodingKey::from_secret(config.jwt_secret.as_bytes()),
             &Validation::default(),
         )
-        .map_err(|_| ApiErrorResponse::BadRequest("Invalid or expired token".to_string()))
+        .map_err(|error| {
+            error!("Failed to validate token: {}", error);
+            ApiErrorResponse::BadRequest("Invalid or expired token".to_string())
+        })
     }
 }

--- a/api/src/auth/user.rs
+++ b/api/src/auth/user.rs
@@ -1,4 +1,5 @@
 use axum::{extract::FromRequestParts, http::request::Parts};
+use log::error;
 use uuid::Uuid;
 
 use crate::auth::jwt::JwtUtil;
@@ -28,8 +29,10 @@ impl FromRequestParts<AppState> for AuthUser {
 
         let token = cookies.strip_prefix("access_token=").unwrap_or("");
 
-        let token_data = JwtUtil::validate_token(token, &state.config)
-            .map_err(|_| ApiErrorResponse::Unauthorized("Invalid or expired token".to_string()))?;
+        let token_data = JwtUtil::validate_token(token, &state.config).map_err(|error| {
+            error!("Failed to validate access token from cookies: {:?}", error);
+            ApiErrorResponse::Unauthorized("Invalid or expired token".to_string())
+        })?;
 
         let user_id = token_data.claims.sub;
 

--- a/api/src/controllers/auth.rs
+++ b/api/src/controllers/auth.rs
@@ -7,7 +7,7 @@ use gig_log_common::models::user::{
     RequestEmailChangeRequest, SetPasswordRequest, SignUpRequest, User,
     VerifyForgotPasswordRequest,
 };
-use log::warn;
+use log::error;
 use sha2::{Digest, Sha256};
 
 use crate::auth::AuthUser;
@@ -31,14 +31,24 @@ impl AuthController {
         State(state): State<AppState>,
         ValidatedJson(body): ValidatedJson<SignUpRequest>,
     ) -> ApiResult<Json<MessageResponse>> {
-        let existing = UserRepo::find_user_by_email(&state.db_pool, &body.email).await;
-        if existing.is_ok() {
-            return Err(ApiErrorResponse::BadRequest(
-                "Email already in use".to_string(),
-            ));
+        match UserRepo::find_user_by_email(&state.db_pool, &body.email).await {
+            Ok(_) => {
+                return Err(ApiErrorResponse::BadRequest(
+                    "Email already in use".to_string(),
+                ));
+            }
+            Err(ApiErrorResponse::NotFound(_)) => {}
+            Err(error) => {
+                error!(
+                    "Failed to check for existing user during sign-up: {:?}",
+                    error
+                );
+                return Err(error);
+            }
         }
 
-        let password_hash = PasswordUtil::hash_password(&body.password).map_err(|_| {
+        let password_hash = PasswordUtil::hash_password(&body.password).map_err(|error| {
+            error!("Failed to hash password during sign-up: {:?}", error);
             ApiErrorResponse::InternalServerError("Failed to hash password".to_string())
         })?;
 
@@ -87,7 +97,10 @@ impl AuthController {
             AuthCodeType::EmailVerification,
         )
         .await
-        .map_err(|_| ApiErrorResponse::BadRequest("Invalid or expired code".to_string()))?;
+        .map_err(|error| {
+            error!("Failed to validate email confirmation code: {:?}", error);
+            ApiErrorResponse::BadRequest("Invalid or expired code".to_string())
+        })?;
 
         AuthCodeRepo::mark_used(&state.db_pool, auth_code.id).await?;
         UserRepo::confirm_email(&state.db_pool, auth_code.user_id).await?;
@@ -106,7 +119,10 @@ impl AuthController {
     ) -> ApiResult<(CookieJar, Json<User>)> {
         let user = UserRepo::find_user_by_email(&state.db_pool, &body.email)
             .await
-            .map_err(|_| ApiErrorResponse::BadRequest("Invalid credentials".to_string()))?;
+            .map_err(|error| {
+                error!("Failed to find user during log-in: {:?}", error);
+                ApiErrorResponse::BadRequest("Invalid credentials".to_string())
+            })?;
 
         if !user.email_confirmed {
             return Err(ApiErrorResponse::BadRequest(
@@ -149,13 +165,13 @@ impl AuthController {
                 RefreshTokenRepo::revoke_token(&state.db_pool, &token_hash).await?;
 
             if !revoked_by_refresh_cookie {
-                warn!(
-                    "Warning: refresh token cookie was present but no active row was revoked; falling back to user-wide revocation"
+                error!(
+                    "Refresh token cookie was present but no active row was revoked; falling back to user-wide revocation"
                 );
             }
         } else {
-            warn!(
-                "Warning: logout request did not include a refresh_token cookie; falling back to user-wide revocation"
+            error!(
+                "Logout request did not include a refresh_token cookie; falling back to user-wide revocation"
             );
         }
 
@@ -169,15 +185,16 @@ impl AuthController {
                         )
                         .await?;
                     }
-                    Err(_) => {
-                        warn!(
-                            "Warning: could not validate access token for fallback logout revocation"
+                    Err(error) => {
+                        error!(
+                            "Could not validate access token for fallback logout revocation: {:?}",
+                            error
                         );
                     }
                 }
             } else {
-                warn!(
-                    "Warning: logout request did not include an access_token cookie for fallback revocation"
+                error!(
+                    "Logout request did not include an access_token cookie for fallback revocation"
                 );
             }
         }
@@ -198,13 +215,24 @@ impl AuthController {
             .ok_or_else(|| ApiErrorResponse::BadRequest("Missing refresh token".to_string()))?;
 
         let old_token = refresh_cookie.value();
-        let token_data = JwtUtil::validate_token(old_token, &state.config)
-            .map_err(|_| ApiErrorResponse::BadRequest("Invalid refresh token".to_string()))?;
+        let token_data = JwtUtil::validate_token(old_token, &state.config).map_err(|error| {
+            error!(
+                "Failed to validate refresh token during token refresh: {:?}",
+                error
+            );
+            ApiErrorResponse::BadRequest("Invalid refresh token".to_string())
+        })?;
         let old_hash = Self::sha256_hash(old_token);
 
         let token_record = RefreshTokenRepo::find_by_hash(&state.db_pool, &old_hash)
             .await
-            .map_err(|_| ApiErrorResponse::BadRequest("Invalid refresh token".to_string()))?;
+            .map_err(|error| {
+                error!(
+                    "Failed to find refresh token record for refresh flow: {:?}",
+                    error
+                );
+                ApiErrorResponse::BadRequest("Invalid refresh token".to_string())
+            })?;
 
         if token_data.claims.sub != token_record.user_id {
             return Err(ApiErrorResponse::BadRequest(
@@ -247,7 +275,19 @@ impl AuthController {
         State(state): State<AppState>,
         ValidatedJson(body): ValidatedJson<ForgotPasswordRequest>,
     ) -> ApiResult<Json<MessageResponse>> {
-        if let Ok(user) = UserRepo::find_user_by_email(&state.db_pool, &body.email).await {
+        let user = match UserRepo::find_user_by_email(&state.db_pool, &body.email).await {
+            Ok(user) => Some(user),
+            Err(ApiErrorResponse::NotFound(_)) => None,
+            Err(error) => {
+                error!(
+                    "Failed to look up user during forgot-password flow: {:?}",
+                    error
+                );
+                return Err(error);
+            }
+        };
+
+        if let Some(user) = user {
             let reset_code = code::generate();
             let expires_at = Utc::now() + Duration::minutes(15);
 
@@ -267,13 +307,12 @@ impl AuthController {
                 reset_code.clone(),
             );
 
-            let result = sender.send_reset_password().await;
-
-            if let Err(_) = result {
+            if let Err(error) = sender.send_reset_password().await {
+                error!("Failed to send forgot-password email: {:?}", error);
                 return Err(ApiErrorResponse::InternalServerError(
                     "Failed to send email".to_string(),
                 ));
-            };
+            }
         }
 
         let response = MessageResponse {
@@ -289,7 +328,8 @@ impl AuthController {
     ) -> ApiResult<Json<MessageResponse>> {
         AuthCodeRepo::find_valid_code(&state.db_pool, &body.code, AuthCodeType::PasswordReset)
             .await
-            .map_err(|_| {
+            .map_err(|error| {
+                error!("Failed to verify forgot-password code: {:?}", error);
                 ApiErrorResponse::BadRequest("Invalid or expired reset code".to_string())
             })?;
 
@@ -305,11 +345,16 @@ impl AuthController {
         let auth_code =
             AuthCodeRepo::find_valid_code(&state.db_pool, &body.code, AuthCodeType::PasswordReset)
                 .await
-                .map_err(|_| {
+                .map_err(|error| {
+                    error!(
+                        "Failed to validate reset code during set-password: {:?}",
+                        error
+                    );
                     ApiErrorResponse::BadRequest("Invalid or expired reset code".to_string())
                 })?;
 
-        let password_hash = PasswordUtil::hash_password(&body.new_password).map_err(|_| {
+        let password_hash = PasswordUtil::hash_password(&body.new_password).map_err(|error| {
+            error!("Failed to hash password during set-password: {:?}", error);
             ApiErrorResponse::InternalServerError("Failed to hash password".to_string())
         })?;
 
@@ -369,7 +414,10 @@ impl AuthController {
         let auth_code =
             AuthCodeRepo::find_valid_code(&state.db_pool, &body.code, AuthCodeType::PasswordChange)
                 .await
-                .map_err(|_| ApiErrorResponse::BadRequest("Invalid or expired code".to_string()))?;
+                .map_err(|error| {
+                    error!("Failed to validate password change code: {:?}", error);
+                    ApiErrorResponse::BadRequest("Invalid or expired code".to_string())
+                })?;
 
         if auth_code.user_id != auth.user_id {
             return Err(ApiErrorResponse::BadRequest(
@@ -379,7 +427,11 @@ impl AuthController {
 
         AuthCodeRepo::mark_used(&state.db_pool, auth_code.id).await?;
 
-        let new_hash = PasswordUtil::hash_password(&body.new_password).map_err(|_| {
+        let new_hash = PasswordUtil::hash_password(&body.new_password).map_err(|error| {
+            error!(
+                "Failed to hash password during password change: {:?}",
+                error
+            );
             ApiErrorResponse::InternalServerError("Failed to hash password".to_string())
         })?;
 
@@ -396,12 +448,20 @@ impl AuthController {
         State(state): State<AppState>,
         ValidatedJson(body): ValidatedJson<RequestEmailChangeRequest>,
     ) -> ApiResult<Json<MessageResponse>> {
-        let existing = UserRepo::find_user_by_email(&state.db_pool, &body.new_email).await;
-
-        if existing.is_ok() {
-            return Err(ApiErrorResponse::BadRequest(
-                "Email already in use".to_string(),
-            ));
+        match UserRepo::find_user_by_email(&state.db_pool, &body.new_email).await {
+            Ok(_) => {
+                return Err(ApiErrorResponse::BadRequest(
+                    "Email already in use".to_string(),
+                ));
+            }
+            Err(ApiErrorResponse::NotFound(_)) => {}
+            Err(error) => {
+                error!(
+                    "Failed to check existing email during request-email-change: {:?}",
+                    error
+                );
+                return Err(error);
+            }
         }
 
         let change_code = code::generate();
@@ -437,7 +497,10 @@ impl AuthController {
         let auth_code =
             AuthCodeRepo::find_valid_code(&state.db_pool, &body.code, AuthCodeType::EmailChange)
                 .await
-                .map_err(|_| ApiErrorResponse::BadRequest("Invalid or expired code".to_string()))?;
+                .map_err(|error| {
+                    error!("Failed to validate email change code: {:?}", error);
+                    ApiErrorResponse::BadRequest("Invalid or expired code".to_string())
+                })?;
 
         let new_email = auth_code.new_email.as_ref().ok_or_else(|| {
             ApiErrorResponse::InternalServerError("Email change code missing new email".to_string())

--- a/api/src/controllers/auth.rs
+++ b/api/src/controllers/auth.rs
@@ -7,7 +7,7 @@ use gig_log_common::models::user::{
     RequestEmailChangeRequest, SetPasswordRequest, SignUpRequest, User,
     VerifyForgotPasswordRequest,
 };
-use log::error;
+use log::{error, warn};
 use sha2::{Digest, Sha256};
 
 use crate::auth::AuthUser;
@@ -165,12 +165,12 @@ impl AuthController {
                 RefreshTokenRepo::revoke_token(&state.db_pool, &token_hash).await?;
 
             if !revoked_by_refresh_cookie {
-                error!(
+                warn!(
                     "Refresh token cookie was present but no active row was revoked; falling back to user-wide revocation"
                 );
             }
         } else {
-            error!(
+            warn!(
                 "Logout request did not include a refresh_token cookie; falling back to user-wide revocation"
             );
         }
@@ -186,14 +186,14 @@ impl AuthController {
                         .await?;
                     }
                     Err(error) => {
-                        error!(
+                        warn!(
                             "Could not validate access token for fallback logout revocation: {:?}",
                             error
                         );
                     }
                 }
             } else {
-                error!(
+                warn!(
                     "Logout request did not include an access_token cookie for fallback revocation"
                 );
             }

--- a/api/src/controllers/auth.rs
+++ b/api/src/controllers/auth.rs
@@ -7,6 +7,7 @@ use gig_log_common::models::user::{
     RequestEmailChangeRequest, SetPasswordRequest, SignUpRequest, User,
     VerifyForgotPasswordRequest,
 };
+use log::warn;
 use sha2::{Digest, Sha256};
 
 use crate::auth::AuthUser;
@@ -148,12 +149,12 @@ impl AuthController {
                 RefreshTokenRepo::revoke_token(&state.db_pool, &token_hash).await?;
 
             if !revoked_by_refresh_cookie {
-                println!(
+                warn!(
                     "Warning: refresh token cookie was present but no active row was revoked; falling back to user-wide revocation"
                 );
             }
         } else {
-            println!(
+            warn!(
                 "Warning: logout request did not include a refresh_token cookie; falling back to user-wide revocation"
             );
         }
@@ -169,13 +170,13 @@ impl AuthController {
                         .await?;
                     }
                     Err(_) => {
-                        println!(
+                        warn!(
                             "Warning: could not validate access token for fallback logout revocation"
                         );
                     }
                 }
             } else {
-                println!(
+                warn!(
                     "Warning: logout request did not include an access_token cookie for fallback revocation"
                 );
             }

--- a/api/src/core/app.rs
+++ b/api/src/core/app.rs
@@ -2,7 +2,7 @@ use sqlx::postgres::PgPoolOptions;
 use tokio::net::TcpListener;
 
 use crate::{
-    core::config::Config,
+    core::{config::Config, logger::Logger},
     email::client::EmailClient,
     routes::app::{AppRouter, AppState},
 };
@@ -13,18 +13,27 @@ pub struct App;
 
 impl App {
     pub async fn run() -> AppResult<()> {
+        Logger::setup_logging_from_env();
+
         let config = Config::new()?;
+        Logger::setup_logging(&config.log_level, config.log_verbose);
+
+        Logger::log_message("Connecting to database");
 
         let db_pool = PgPoolOptions::new()
             .max_connections(5)
             .connect(&config.database_url)
             .await?;
 
-        let email_client = EmailClient::new(&config);
+        Logger::log_success("Database connection established");
 
         if config.auto_apply_migrations {
-            sqlx::migrate!().run(&db_pool).await?
+            Logger::log_message("Checking for pending database migrations");
+            sqlx::migrate!().run(&db_pool).await?;
+            Logger::log_success("Database migrations are up to date");
         }
+
+        let email_client = EmailClient::new(&config);
 
         let state = AppState {
             config,
@@ -35,8 +44,8 @@ impl App {
 
         let listener = TcpListener::bind("0.0.0.0:8000").await?;
 
-        println!("Server running on port 8000");
-        axum::serve(listener, app).await.unwrap();
+        Logger::log_success("Server running on port 8000");
+        axum::serve(listener, app).await?;
 
         Ok(())
     }

--- a/api/src/core/config.rs
+++ b/api/src/core/config.rs
@@ -2,6 +2,7 @@ use std::env;
 
 use anyhow::Error;
 use dotenvy::dotenv;
+use log::error;
 
 use crate::core::app::AppResult;
 
@@ -97,7 +98,13 @@ impl Config {
                 match value.trim().to_ascii_lowercase().as_str() {
                     "true" => true,
                     "false" => false,
-                    _ => default,
+                    _ => {
+                        error!(
+                            "Invalid boolean value for {}='{}'; using default {}",
+                            var, value, default
+                        );
+                        default
+                    }
                 }
             }
             _ => default,
@@ -108,7 +115,13 @@ impl Config {
         match env::var(var) {
             Ok(value) if !value.trim().is_empty() => match value.parse::<usize>() {
                 Ok(value) => value,
-                Err(_) => default,
+                Err(error) => {
+                    error!(
+                        "Invalid usize value for {}='{}': {}; using default {}",
+                        var, value, error, default
+                    );
+                    default
+                }
             },
             _ => default,
         }
@@ -118,7 +131,13 @@ impl Config {
         match env::var(var) {
             Ok(value) if !value.trim().is_empty() => match value.parse::<u64>() {
                 Ok(value) => value,
-                Err(_) => default,
+                Err(error) => {
+                    error!(
+                        "Invalid number value for {}='{}': {}; using default {}",
+                        var, value, error, default
+                    );
+                    default
+                }
             },
             _ => default,
         }

--- a/api/src/core/config.rs
+++ b/api/src/core/config.rs
@@ -19,7 +19,7 @@ pub struct Config {
     pub auth_code_expiry_seconds: u64,
     pub log_level: String,
     pub log_verbose: bool,
-    pub log_http_max_body: u64,
+    pub log_http_max_body: usize,
 }
 
 impl Config {
@@ -39,8 +39,9 @@ impl Config {
         let resend_from_email = Self::get_var_from_env("RESEND_FROM_EMAIL")?;
         let auth_code_expiry_seconds = Self::get_optional_number("AUTH_CODE_EXPIRY_SECONDS", 600);
         let log_level = Self::get_optional_string("LOG_LEVEL", "debug");
-        let log_verbose = Self::get_optional_bool("LOG_VERBOSE", true);
-        let log_http_max_body = Self::get_optional_number("LOG_HTTP_MAX_BODY_BYTES", 16384);
+        let log_verbose =
+            Self::get_optional_bool("LOG_VERBOSE", Self::is_development_env(&app_env));
+        let log_http_max_body = Self::get_optional_usize("LOG_HTTP_MAX_BODY_BYTES", 16384);
 
         Ok(Self {
             app_env,
@@ -61,6 +62,10 @@ impl Config {
 
     pub fn is_development(&self) -> bool {
         Self::is_development_env(&self.app_env)
+    }
+
+    pub fn is_http_body_logging_enabled(&self) -> bool {
+        self.is_development()
     }
 
     pub fn is_development_env(app_env: &str) -> bool {
@@ -88,10 +93,22 @@ impl Config {
 
     fn get_optional_bool(var: &str, default: bool) -> bool {
         match env::var(var) {
-            Ok(value) if !value.trim().is_empty() => match value.as_str() {
-                "true" => true,
-                "false" => false,
-                _ => default,
+            Ok(value) if !value.trim().is_empty() => {
+                match value.trim().to_ascii_lowercase().as_str() {
+                    "true" => true,
+                    "false" => false,
+                    _ => default,
+                }
+            }
+            _ => default,
+        }
+    }
+
+    fn get_optional_usize(var: &str, default: usize) -> usize {
+        match env::var(var) {
+            Ok(value) if !value.trim().is_empty() => match value.parse::<usize>() {
+                Ok(value) => value,
+                Err(_) => default,
             },
             _ => default,
         }

--- a/api/src/core/config.rs
+++ b/api/src/core/config.rs
@@ -96,8 +96,8 @@ impl Config {
         match env::var(var) {
             Ok(value) if !value.trim().is_empty() => {
                 match value.trim().to_ascii_lowercase().as_str() {
-                    "true" => true,
-                    "false" => false,
+                    "true" | "1" | "yes" | "on" => true,
+                    "false" | "0" | "no" | "off" => false,
                     _ => {
                         error!(
                             "Invalid boolean value for {}='{}'; using default {}",

--- a/api/src/core/error.rs
+++ b/api/src/core/error.rs
@@ -21,15 +21,25 @@ pub enum ApiErrorResponse {
 impl IntoResponse for ApiErrorResponse {
     fn into_response(self) -> Response {
         let (status, message, errors) = match self {
-            ApiErrorResponse::NotFound(msg) => (StatusCode::NOT_FOUND, msg, None),
-            ApiErrorResponse::BadRequest(msg) => (StatusCode::BAD_REQUEST, msg, None),
-            ApiErrorResponse::Validation(errs) => (
-                StatusCode::BAD_REQUEST,
-                "Validation Error".to_string(),
-                Some(errs),
-            ),
+            ApiErrorResponse::NotFound(msg) => {
+                error!("NotFound: {}", msg);
+                (StatusCode::NOT_FOUND, msg, None)
+            }
+            ApiErrorResponse::BadRequest(msg) => {
+                error!("BadRequest: {}", msg);
+                (StatusCode::BAD_REQUEST, msg, None)
+            }
+            ApiErrorResponse::Validation(errs) => {
+                error!("Validation error: {:?}", errs);
+
+                (
+                    StatusCode::BAD_REQUEST,
+                    "Validation Error".to_string(),
+                    Some(errs),
+                )
+            }
             ApiErrorResponse::InternalServerError(msg) => {
-                error!("Error: {:#}", msg);
+                error!("InternalServerError: {}", msg);
 
                 (
                     StatusCode::INTERNAL_SERVER_ERROR,
@@ -37,7 +47,10 @@ impl IntoResponse for ApiErrorResponse {
                     None,
                 )
             }
-            ApiErrorResponse::Unauthorized(msg) => (StatusCode::UNAUTHORIZED, msg, None),
+            ApiErrorResponse::Unauthorized(msg) => {
+                error!("Unauthorized: {}", msg);
+                (StatusCode::UNAUTHORIZED, msg, None)
+            }
         };
 
         let body = ApiError {

--- a/api/src/core/error.rs
+++ b/api/src/core/error.rs
@@ -5,6 +5,7 @@ use axum::{
     response::{IntoResponse, Response},
 };
 use gig_log_common::models::error::{ApiError, ValidationError};
+use log::error;
 
 pub type ApiResult<T> = Result<T, ApiErrorResponse>;
 
@@ -28,7 +29,7 @@ impl IntoResponse for ApiErrorResponse {
                 Some(errs),
             ),
             ApiErrorResponse::InternalServerError(msg) => {
-                println!("Error: {:#?}", msg);
+                error!("Error: {:#}", msg);
 
                 (
                     StatusCode::INTERNAL_SERVER_ERROR,

--- a/api/src/core/error.rs
+++ b/api/src/core/error.rs
@@ -1,11 +1,11 @@
 use axum::{
-    Json,
     extract::rejection::JsonRejection,
     http::StatusCode,
     response::{IntoResponse, Response},
+    Json,
 };
 use gig_log_common::models::error::{ApiError, ValidationError};
-use log::error;
+use log::{error, warn};
 
 pub type ApiResult<T> = Result<T, ApiErrorResponse>;
 
@@ -22,15 +22,15 @@ impl IntoResponse for ApiErrorResponse {
     fn into_response(self) -> Response {
         let (status, message, errors) = match self {
             ApiErrorResponse::NotFound(msg) => {
-                error!("NotFound: {}", msg);
+                warn!("NotFound: {}", msg);
                 (StatusCode::NOT_FOUND, msg, None)
             }
             ApiErrorResponse::BadRequest(msg) => {
-                error!("BadRequest: {}", msg);
+                warn!("BadRequest: {}", msg);
                 (StatusCode::BAD_REQUEST, msg, None)
             }
             ApiErrorResponse::Validation(errs) => {
-                error!("Validation error: {:?}", errs);
+                warn!("Validation error: {:?}", errs);
 
                 (
                     StatusCode::BAD_REQUEST,
@@ -48,7 +48,7 @@ impl IntoResponse for ApiErrorResponse {
                 )
             }
             ApiErrorResponse::Unauthorized(msg) => {
-                error!("Unauthorized: {}", msg);
+                warn!("Unauthorized: {}", msg);
                 (StatusCode::UNAUTHORIZED, msg, None)
             }
         };

--- a/api/src/core/logger/backend.rs
+++ b/api/src/core/logger/backend.rs
@@ -4,7 +4,8 @@ use std::{
 };
 
 use colorized::{Colors, colorize_println};
-use log::{Level, LevelFilter, Log, Metadata, Record, set_logger, set_max_level};
+use gig_log_common::logging::parse_level_filter;
+use log::{Level, Log, Metadata, Record, set_logger, set_max_level};
 
 use super::formatting::{extract_after_src, get_hashtags, log_debug, log_error};
 
@@ -18,7 +19,7 @@ impl Logger {
         LOG_VERBOSE.store(verbose, Ordering::Relaxed);
 
         let _ = set_logger(&LOGGER);
-        set_max_level(Self::parse_level_filter(log_level));
+        set_max_level(parse_level_filter(log_level));
     }
 
     pub fn setup_logging_from_env() {
@@ -62,18 +63,6 @@ impl Logger {
         }
 
         colorize_println(message, Colors::BlueFg);
-    }
-
-    fn parse_level_filter(log_level: &str) -> LevelFilter {
-        match log_level.trim().to_ascii_lowercase().as_str() {
-            "off" => LevelFilter::Off,
-            "error" => LevelFilter::Error,
-            "warn" => LevelFilter::Warn,
-            "info" => LevelFilter::Info,
-            "debug" => LevelFilter::Debug,
-            "trace" => LevelFilter::Trace,
-            _ => LevelFilter::Info,
-        }
     }
 }
 

--- a/api/src/core/logger/backend.rs
+++ b/api/src/core/logger/backend.rs
@@ -1,0 +1,142 @@
+use std::{
+    env,
+    sync::atomic::{AtomicBool, Ordering},
+};
+
+use colorized::{Colors, colorize_println};
+use log::{Level, LevelFilter, Log, Metadata, Record, set_logger, set_max_level};
+
+use super::formatting::{extract_after_src, get_hashtags, log_debug, log_error};
+
+pub struct Logger;
+
+static LOGGER: Logger = Logger;
+static LOG_VERBOSE: AtomicBool = AtomicBool::new(true);
+
+impl Logger {
+    pub fn setup_logging(log_level: &str, verbose: bool) {
+        LOG_VERBOSE.store(verbose, Ordering::Relaxed);
+
+        let _ = set_logger(&LOGGER);
+        set_max_level(Self::parse_level_filter(log_level));
+    }
+
+    pub fn setup_logging_from_env() {
+        dotenvy::dotenv().ok();
+
+        let level = env::var("LOG_LEVEL").unwrap_or_else(|_| "info".to_string());
+        let verbose = env::var("LOG_VERBOSE")
+            .ok()
+            .map(|value| {
+                matches!(
+                    value.trim().to_ascii_lowercase().as_str(),
+                    "true" | "1" | "yes" | "on"
+                )
+            })
+            .unwrap_or(true);
+
+        Self::setup_logging(&level, verbose);
+    }
+
+    pub fn is_verbose() -> bool {
+        LOG_VERBOSE.load(Ordering::Relaxed)
+    }
+
+    pub fn log_success(message: &str) {
+        if Self::is_verbose() {
+            let hashtags = get_hashtags(6);
+            let message = format!("\n{} {} {}\n", hashtags, message, hashtags);
+            colorize_println(message, Colors::GreenFg);
+            return;
+        }
+
+        colorize_println(message, Colors::GreenFg);
+    }
+
+    pub fn log_message(message: &str) {
+        if Self::is_verbose() {
+            let hashtags = get_hashtags(6);
+            let message = format!("\n{} {} {}\n", hashtags, message, hashtags);
+            colorize_println(message, Colors::BlueFg);
+            return;
+        }
+
+        colorize_println(message, Colors::BlueFg);
+    }
+
+    fn parse_level_filter(log_level: &str) -> LevelFilter {
+        match log_level.trim().to_ascii_lowercase().as_str() {
+            "off" => LevelFilter::Off,
+            "error" => LevelFilter::Error,
+            "warn" => LevelFilter::Warn,
+            "info" => LevelFilter::Info,
+            "debug" => LevelFilter::Debug,
+            "trace" => LevelFilter::Trace,
+            _ => LevelFilter::Info,
+        }
+    }
+}
+
+impl Log for Logger {
+    fn enabled(&self, _: &Metadata<'_>) -> bool {
+        true
+    }
+
+    fn log(&self, record: &Record<'_>) {
+        if !self.enabled(record.metadata()) {
+            return;
+        }
+
+        let file_path = extract_after_src(record.file());
+
+        if file_path.contains("index.crates") {
+            return;
+        }
+
+        if !Logger::is_verbose() {
+            match record.level() {
+                Level::Error => {
+                    colorize_println(format!("[ERROR] {}", record.args()), Colors::RedFg)
+                }
+                Level::Warn => {
+                    colorize_println(format!("[WARN] {}", record.args()), Colors::YellowFg)
+                }
+                Level::Info => println!("{}", record.args()),
+                Level::Debug => {
+                    colorize_println(format!("[DEBUG] {}", record.args()), Colors::BlueFg)
+                }
+                Level::Trace => {
+                    colorize_println(format!("[TRACE] {}", record.args()), Colors::MagentaFg)
+                }
+            }
+
+            return;
+        }
+
+        let blue = "\x1b[34m";
+        let purple = "\x1b[35m";
+        let clear = "\x1b[0m";
+        let line_number = record
+            .line()
+            .map(|line| line.to_string())
+            .unwrap_or_default();
+
+        match record.level() {
+            Level::Info => println!("\n{}{}{}", blue, record.args(), clear),
+            Level::Error => log_error(record),
+            Level::Debug => log_debug(record),
+            _ => println!(
+                "\n{}File: {}{}\n{}Line Number: {}{}\n{}",
+                purple,
+                file_path,
+                clear,
+                purple,
+                line_number,
+                clear,
+                record.args(),
+            ),
+        }
+    }
+
+    fn flush(&self) {}
+}

--- a/api/src/core/logger/backend.rs
+++ b/api/src/core/logger/backend.rs
@@ -3,9 +3,9 @@ use std::{
     sync::atomic::{AtomicBool, Ordering},
 };
 
-use colorized::{Colors, colorize_println};
+use colorized::{colorize_println, Colors};
 use gig_log_common::logging::parse_level_filter;
-use log::{Level, Log, Metadata, Record, set_logger, set_max_level};
+use log::{set_logger, set_max_level, Level, Log, Metadata, Record};
 
 use super::formatting::{extract_after_src, get_hashtags, log_debug, log_error};
 
@@ -28,11 +28,10 @@ impl Logger {
         let level = env::var("LOG_LEVEL").unwrap_or_else(|_| "info".to_string());
         let verbose = env::var("LOG_VERBOSE")
             .ok()
-            .map(|value| {
-                matches!(
-                    value.trim().to_ascii_lowercase().as_str(),
-                    "true" | "1" | "yes" | "on"
-                )
+            .map(|value| match value.trim().to_ascii_lowercase().as_str() {
+                "true" | "1" | "yes" | "on" => true,
+                "false" | "0" | "no" | "off" => false,
+                _ => true,
             })
             .unwrap_or(true);
 
@@ -44,6 +43,10 @@ impl Logger {
     }
 
     pub fn log_success(message: &str) {
+        if !log::log_enabled!(Level::Info) {
+            return;
+        }
+
         if Self::is_verbose() {
             let hashtags = get_hashtags(6);
             let message = format!("\n{} {} {}\n", hashtags, message, hashtags);
@@ -55,6 +58,10 @@ impl Logger {
     }
 
     pub fn log_message(message: &str) {
+        if !log::log_enabled!(Level::Info) {
+            return;
+        }
+
         if Self::is_verbose() {
             let hashtags = get_hashtags(6);
             let message = format!("\n{} {} {}\n", hashtags, message, hashtags);

--- a/api/src/core/logger/formatting.rs
+++ b/api/src/core/logger/formatting.rs
@@ -1,0 +1,315 @@
+use axum::http::{HeaderMap, Method, StatusCode};
+use colorized::{Colors, colorize_print, colorize_println};
+use log::Record;
+use serde_json::Value;
+use uuid::Uuid;
+
+use super::redaction::sanitize_header_value;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(super) enum StatusClass {
+    Success,
+    ClientError,
+    ServerError,
+    Other,
+}
+
+pub(super) fn classify_status(status_code: StatusCode) -> StatusClass {
+    if status_code.is_success() {
+        StatusClass::Success
+    } else if status_code.is_client_error() {
+        StatusClass::ClientError
+    } else if status_code.is_server_error() {
+        StatusClass::ServerError
+    } else {
+        StatusClass::Other
+    }
+}
+
+pub(super) fn get_hashtags(level: i8) -> String {
+    let mut hashtags = String::new();
+
+    for _ in 0..level {
+        hashtags.push('#');
+    }
+
+    hashtags
+}
+
+pub(super) fn get_spaces(level: i8) -> String {
+    let mut spaces = String::new();
+
+    for _ in 0..level {
+        spaces.push_str("  ");
+    }
+
+    spaces
+}
+
+fn log_header(header: &str, hashtags: &str) {
+    let header_string = format!("\n{} {} {}\n", hashtags, header, hashtags);
+    colorize_println(header_string, Colors::MagentaFg);
+}
+
+fn log_h1(header: &str) {
+    log_header(header, &get_hashtags(6));
+}
+
+fn log_h2(header: &str) {
+    log_header(header, &get_hashtags(5));
+}
+
+pub(super) fn log_json(json: Value, level: i8) {
+    match json {
+        Value::Array(values) => {
+            log_array(values, level);
+        }
+        json => {
+            if let Some(json_object) = json.as_object() {
+                if level == 0 {
+                    println!("{{");
+                }
+
+                for (key, value) in json_object {
+                    print!("{}", get_spaces(level + 1));
+                    colorize_print(key, Colors::CyanFg);
+                    print!(": ");
+
+                    match value {
+                        Value::Array(values) => log_array(values.clone(), level + 1),
+                        Value::String(value) => {
+                            colorize_print(format!("\"{}\"", value), Colors::GreenFg);
+                            println!(",");
+                        }
+                        Value::Object(value) => {
+                            println!("{{");
+                            log_json(Value::Object(value.clone()), level + 2);
+                            print!("{}", get_spaces(level + 1));
+                            println!("}},");
+                        }
+                        value => {
+                            colorize_print(value.to_string(), Colors::MagentaFg);
+                            println!(",");
+                        }
+                    }
+                }
+
+                if level == 0 {
+                    println!("}}");
+                }
+            }
+        }
+    }
+}
+
+fn log_array(values: Vec<Value>, level: i8) {
+    if values.is_empty() {
+        println!("[],");
+        return;
+    }
+
+    if level > 0 {
+        print!("\n{}", get_spaces(level));
+    }
+
+    println!("[");
+
+    for (index, value) in values.iter().enumerate() {
+        print!("{}", get_spaces(level + 1));
+        println!("{{");
+        log_json(value.to_owned(), level + 2);
+        print!("{}", get_spaces(level + 1));
+
+        if index == values.len() - 1 {
+            println!("}}");
+        } else {
+            println!("}},");
+        }
+    }
+
+    if level > 0 {
+        print!("{}", get_spaces(level));
+    }
+
+    if level == 0 {
+        println!("]");
+    } else {
+        println!("],");
+    }
+}
+
+pub(super) fn log_headers(headers: &HeaderMap) {
+    for (key, value) in headers {
+        colorize_print(format!("{}: ", key), Colors::CyanFg);
+        let value = value.to_str().unwrap_or("<non-utf8>");
+        let sanitized = sanitize_header_value(key.as_str(), value);
+        println!("{}", sanitized);
+    }
+}
+
+pub(super) fn log_request(
+    id: Uuid,
+    method: &Method,
+    route: &str,
+    headers: &HeaderMap,
+    req_body: Option<Value>,
+) {
+    log_h1("Request");
+
+    colorize_print("Request ID: ", Colors::CyanFg);
+    println!("{}\n", id);
+
+    colorize_print(format!("{} ", method), Colors::CyanFg);
+    println!("{}", route);
+
+    log_h2("Headers");
+    log_headers(headers);
+
+    if let Some(req_body) = req_body {
+        log_h2("Body");
+        log_json(req_body, 0);
+    }
+}
+
+pub(super) fn log_response(
+    id: Uuid,
+    status_code: StatusCode,
+    duration_ms: u128,
+    res_body: Option<Value>,
+) {
+    log_h1("Response");
+
+    colorize_print("Request ID: ", Colors::CyanFg);
+    println!("{}\n", id);
+
+    colorize_print("Status Code: ", Colors::CyanFg);
+
+    match classify_status(status_code) {
+        StatusClass::Success => colorize_println(status_code.to_string(), Colors::GreenFg),
+        StatusClass::ClientError => colorize_println(status_code.to_string(), Colors::YellowFg),
+        StatusClass::ServerError => colorize_println(status_code.to_string(), Colors::RedFg),
+        StatusClass::Other => colorize_println(status_code.to_string(), Colors::MagentaFg),
+    }
+
+    colorize_print("Duration: ", Colors::CyanFg);
+    colorize_println(format!("{} ms", duration_ms), Colors::BlueFg);
+
+    if let Some(res_body) = res_body {
+        log_h2("Body");
+        log_json(res_body, 0);
+    }
+}
+
+pub(super) fn log_compact_http(
+    id: Uuid,
+    method: &Method,
+    route: &str,
+    status_code: StatusCode,
+    duration_ms: u128,
+) {
+    colorize_print(format!("[{}] ", id), Colors::CyanFg);
+    colorize_print(format!("{} {} -> ", method, route), Colors::BlueFg);
+
+    match classify_status(status_code) {
+        StatusClass::Success => colorize_print(status_code.to_string(), Colors::GreenFg),
+        StatusClass::ClientError => colorize_print(status_code.to_string(), Colors::YellowFg),
+        StatusClass::ServerError => colorize_print(status_code.to_string(), Colors::RedFg),
+        StatusClass::Other => colorize_print(status_code.to_string(), Colors::MagentaFg),
+    }
+
+    colorize_println(format!(" ({} ms)", duration_ms), Colors::BlueFg);
+}
+
+pub(super) fn extract_after_src(path: Option<&str>) -> String {
+    match path {
+        Some(path) => {
+            let src_prefix = "src/";
+
+            if let Some(start_index) = path.find(src_prefix) {
+                let start_index = start_index + src_prefix.len();
+                path[start_index..].to_string()
+            } else {
+                String::new()
+            }
+        }
+        None => String::new(),
+    }
+}
+
+pub(super) fn log_error(record: &Record<'_>) {
+    let hashtags = get_hashtags(6);
+    let error_header = format!("\n{} Error {}\n", hashtags, hashtags);
+    let file_path = extract_after_src(record.file());
+    let line_number = record
+        .line()
+        .map(|line| line.to_string())
+        .unwrap_or_default();
+
+    colorize_println(error_header, Colors::RedFg);
+    colorize_println(
+        format!("File: {}\nLine Number: {}\n", file_path, line_number),
+        Colors::RedFg,
+    );
+    colorize_println(format!("{}", record.args()), Colors::RedFg);
+}
+
+pub(super) fn log_debug(record: &Record<'_>) {
+    let hashtags = get_hashtags(6);
+    let debug_header = format!("\n{} Debug {}\n", hashtags, hashtags);
+    let file_path = extract_after_src(record.file());
+    let line_number = record
+        .line()
+        .map(|line| line.to_string())
+        .unwrap_or_default();
+
+    colorize_println(debug_header, Colors::YellowFg);
+    colorize_println(
+        format!("File: {}\nLine Number: {}\n", file_path, line_number),
+        Colors::YellowFg,
+    );
+    colorize_println(format!("{}", record.args()), Colors::YellowFg);
+}
+
+#[cfg(test)]
+mod tests {
+    use axum::http::StatusCode;
+
+    use super::{StatusClass, classify_status, extract_after_src, get_hashtags, get_spaces};
+
+    #[test]
+    fn classify_status_maps_expected_classes() {
+        assert_eq!(classify_status(StatusCode::OK), StatusClass::Success);
+        assert_eq!(
+            classify_status(StatusCode::BAD_REQUEST),
+            StatusClass::ClientError
+        );
+        assert_eq!(
+            classify_status(StatusCode::INTERNAL_SERVER_ERROR),
+            StatusClass::ServerError
+        );
+        assert_eq!(
+            classify_status(StatusCode::SWITCHING_PROTOCOLS),
+            StatusClass::Other
+        );
+    }
+
+    #[test]
+    fn extract_after_src_returns_relative_suffix() {
+        let extracted = extract_after_src(Some("/tmp/project/src/core/logger/mod.rs"));
+        assert_eq!(extracted, "core/logger/mod.rs");
+    }
+
+    #[test]
+    fn extract_after_src_returns_empty_when_src_not_found() {
+        let extracted = extract_after_src(Some("/tmp/project/core/logger/mod.rs"));
+        assert!(extracted.is_empty());
+    }
+
+    #[test]
+    fn banner_and_indent_helpers_are_deterministic() {
+        assert_eq!(get_hashtags(0), "");
+        assert_eq!(get_hashtags(3), "###");
+        assert_eq!(get_spaces(0), "");
+        assert_eq!(get_spaces(2), "    ");
+    }
+}

--- a/api/src/core/logger/formatting.rs
+++ b/api/src/core/logger/formatting.rs
@@ -238,35 +238,35 @@ pub(super) fn extract_after_src(path: Option<&str>) -> String {
 
 pub(super) fn log_error(record: &Record<'_>) {
     let hashtags = get_hashtags(6);
-    let error_header = format!("\n{} Error {}\n", hashtags, hashtags);
+    let error_header = format!("{} Error {}", hashtags, hashtags);
     let file_path = extract_after_src(record.file());
     let line_number = record
         .line()
         .map(|line| line.to_string())
         .unwrap_or_default();
 
+    println!();
     colorize_println(error_header, Colors::RedFg);
-    colorize_println(
-        format!("File: {}\nLine Number: {}\n", file_path, line_number),
-        Colors::RedFg,
-    );
+    colorize_println(format!("File: {}", file_path), Colors::RedFg);
+    colorize_println(format!("Line Number: {}", line_number), Colors::RedFg);
+    println!();
     colorize_println(format!("{}", record.args()), Colors::RedFg);
 }
 
 pub(super) fn log_debug(record: &Record<'_>) {
     let hashtags = get_hashtags(6);
-    let debug_header = format!("\n{} Debug {}\n", hashtags, hashtags);
+    let debug_header = format!("{} Debug {}", hashtags, hashtags);
     let file_path = extract_after_src(record.file());
     let line_number = record
         .line()
         .map(|line| line.to_string())
         .unwrap_or_default();
 
+    println!();
     colorize_println(debug_header, Colors::YellowFg);
-    colorize_println(
-        format!("File: {}\nLine Number: {}\n", file_path, line_number),
-        Colors::YellowFg,
-    );
+    colorize_println(format!("File: {}", file_path), Colors::YellowFg);
+    colorize_println(format!("Line Number: {}", line_number), Colors::YellowFg);
+    println!();
     colorize_println(format!("{}", record.args()), Colors::YellowFg);
 }
 

--- a/api/src/core/logger/middleware.rs
+++ b/api/src/core/logger/middleware.rs
@@ -72,7 +72,7 @@ impl Logger {
                     (logged_body, Body::from(bytes))
                 }
                 Err(error) => {
-                    log::debug!(
+                    log::error!(
                         "Skipping request body logging for request {} (failed to buffer request body: {})",
                         request_id,
                         error
@@ -124,7 +124,7 @@ impl Logger {
                 (logged_body, Body::from(bytes))
             }
             Err(error) => {
-                log::debug!(
+                log::error!(
                     "Skipping response body logging for request {} (failed to buffer response body: {})",
                     request_id,
                     error
@@ -176,9 +176,9 @@ fn should_attempt_response_body_logging(
         return false;
     }
 
-    match content_length(headers).or_else(|| {
-        body_size_hint_upper.and_then(|upper_bound| usize::try_from(upper_bound).ok())
-    }) {
+    match content_length(headers)
+        .or_else(|| body_size_hint_upper.and_then(|upper_bound| usize::try_from(upper_bound).ok()))
+    {
         Some(length) => length <= config.max_body_bytes,
         None => false,
     }
@@ -273,17 +273,25 @@ mod tests {
             verbose: true,
         };
 
-        assert!(should_attempt_response_body_logging(&headers, None, &config));
+        assert!(should_attempt_response_body_logging(
+            &headers, None, &config
+        ));
 
         headers.remove(header::CONTENT_LENGTH);
 
-        assert!(should_attempt_response_body_logging(&headers, Some(48), &config));
+        assert!(should_attempt_response_body_logging(
+            &headers,
+            Some(48),
+            &config
+        ));
         assert!(!should_attempt_response_body_logging(
             &headers,
             Some(256),
             &config
         ));
-        assert!(!should_attempt_response_body_logging(&headers, None, &config));
+        assert!(!should_attempt_response_body_logging(
+            &headers, None, &config
+        ));
     }
 
     #[test]

--- a/api/src/core/logger/middleware.rs
+++ b/api/src/core/logger/middleware.rs
@@ -1,0 +1,321 @@
+use std::time::Instant;
+
+use axum::{
+    body::{Body, to_bytes},
+    extract::{Request, State},
+    http::{
+        Method,
+        header::{CONTENT_LENGTH, CONTENT_TYPE, HeaderMap},
+    },
+    middleware::Next,
+    response::Response,
+};
+use log::Level;
+use uuid::Uuid;
+
+use super::{
+    Logger,
+    formatting::{log_compact_http, log_request, log_response},
+    redaction::parse_redacted_json,
+};
+
+#[derive(Debug, Clone)]
+pub struct HttpLoggingConfig {
+    pub body_enabled: bool,
+    pub max_body_bytes: usize,
+    pub verbose: bool,
+}
+
+impl HttpLoggingConfig {
+    pub fn new(body_enabled: bool, max_body_bytes: usize, verbose: bool) -> Self {
+        Self {
+            body_enabled,
+            max_body_bytes,
+            verbose,
+        }
+    }
+}
+
+impl Default for HttpLoggingConfig {
+    fn default() -> Self {
+        Self {
+            body_enabled: false,
+            max_body_bytes: 16 * 1024,
+            verbose: true,
+        }
+    }
+}
+
+impl Logger {
+    pub async fn log_request_and_response(
+        State(config): State<HttpLoggingConfig>,
+        request: Request,
+        next: Next,
+    ) -> Response {
+        if !log::log_enabled!(Level::Info) {
+            return next.run(request).await;
+        }
+
+        let request_id = Uuid::new_v4();
+        let use_verbose_http_logs = config.verbose || config.body_enabled;
+        let (request_parts, request_body) = request.into_parts();
+        let method = request_parts.method.clone();
+        let path = request_parts.uri.path().to_string();
+        let headers = request_parts.headers.clone();
+
+        let (logged_request_body, request_body_for_next) = if should_attempt_request_body_logging(
+            &method, &headers, &config,
+        ) {
+            match to_bytes(request_body, usize::MAX).await {
+                Ok(bytes) => {
+                    let logged_body = parse_redacted_json(&bytes);
+                    (logged_body, Body::from(bytes))
+                }
+                Err(error) => {
+                    log::debug!(
+                        "Skipping request body logging for request {} (failed to buffer request body: {})",
+                        request_id,
+                        error
+                    );
+
+                    (None, Body::empty())
+                }
+            }
+        } else {
+            (None, request_body)
+        };
+
+        let request = Request::from_parts(request_parts, request_body_for_next);
+
+        if use_verbose_http_logs {
+            log_request(request_id, &method, &path, &headers, logged_request_body);
+        }
+
+        let started_at = Instant::now();
+        let response = next.run(request).await;
+        let duration_ms = started_at.elapsed().as_millis();
+        let status = response.status();
+
+        if !use_verbose_http_logs {
+            log_compact_http(request_id, &method, &path, status, duration_ms);
+            return response;
+        }
+
+        let response_headers = response.headers().clone();
+
+        if !should_attempt_response_body_logging(&response_headers, &config) {
+            log_response(request_id, status, duration_ms, None);
+            return response;
+        }
+
+        let (response_parts, response_body) = response.into_parts();
+        let (logged_response_body, response_body_for_client) = match to_bytes(
+            response_body,
+            usize::MAX,
+        )
+        .await
+        {
+            Ok(bytes) => {
+                let logged_body = parse_redacted_json(&bytes);
+                (logged_body, Body::from(bytes))
+            }
+            Err(error) => {
+                log::debug!(
+                    "Skipping response body logging for request {} (failed to buffer response body: {})",
+                    request_id,
+                    error
+                );
+
+                (None, Body::empty())
+            }
+        };
+
+        log_response(request_id, status, duration_ms, logged_response_body);
+
+        Response::from_parts(response_parts, response_body_for_client)
+    }
+}
+
+fn should_attempt_request_body_logging(
+    method: &Method,
+    headers: &HeaderMap,
+    config: &HttpLoggingConfig,
+) -> bool {
+    if !config.body_enabled {
+        return false;
+    }
+
+    if matches!(method, &Method::GET | &Method::DELETE | &Method::HEAD) {
+        return false;
+    }
+
+    if !is_json_content_type(headers) {
+        return false;
+    }
+
+    match content_length(headers) {
+        Some(length) => length <= config.max_body_bytes,
+        None => false,
+    }
+}
+
+fn should_attempt_response_body_logging(headers: &HeaderMap, config: &HttpLoggingConfig) -> bool {
+    if !config.body_enabled {
+        return false;
+    }
+
+    if !is_json_content_type(headers) {
+        return false;
+    }
+
+    match content_length(headers) {
+        Some(length) => length <= config.max_body_bytes,
+        None => false,
+    }
+}
+
+fn is_json_content_type(headers: &HeaderMap) -> bool {
+    let content_type = headers
+        .get(CONTENT_TYPE)
+        .and_then(|value| value.to_str().ok())
+        .map(|value| value.to_ascii_lowercase());
+
+    match content_type {
+        Some(content_type) => {
+            content_type.contains("application/json") || content_type.contains("+json")
+        }
+        None => false,
+    }
+}
+
+fn content_length(headers: &HeaderMap) -> Option<usize> {
+    headers
+        .get(CONTENT_LENGTH)
+        .and_then(|value| value.to_str().ok())
+        .and_then(|value| value.parse::<usize>().ok())
+}
+
+#[cfg(test)]
+mod tests {
+    use axum::http::{Method, header};
+
+    use super::{
+        HttpLoggingConfig, should_attempt_request_body_logging,
+        should_attempt_response_body_logging,
+    };
+
+    #[test]
+    fn request_body_logging_requires_json_with_allowed_method_and_size() {
+        let mut headers = header::HeaderMap::new();
+        headers.insert(
+            header::CONTENT_TYPE,
+            header::HeaderValue::from_static("application/json"),
+        );
+        headers.insert(
+            header::CONTENT_LENGTH,
+            header::HeaderValue::from_static("8"),
+        );
+
+        let config = HttpLoggingConfig {
+            body_enabled: true,
+            max_body_bytes: 16,
+            verbose: true,
+        };
+
+        assert!(should_attempt_request_body_logging(
+            &Method::POST,
+            &headers,
+            &config
+        ));
+        assert!(!should_attempt_request_body_logging(
+            &Method::GET,
+            &headers,
+            &config
+        ));
+
+        headers.insert(
+            header::CONTENT_LENGTH,
+            header::HeaderValue::from_static("32"),
+        );
+
+        assert!(!should_attempt_request_body_logging(
+            &Method::POST,
+            &headers,
+            &config
+        ));
+    }
+
+    #[test]
+    fn response_body_logging_requires_known_size_within_limit() {
+        let mut headers = header::HeaderMap::new();
+        headers.insert(
+            header::CONTENT_TYPE,
+            header::HeaderValue::from_static("application/json"),
+        );
+        headers.insert(
+            header::CONTENT_LENGTH,
+            header::HeaderValue::from_static("48"),
+        );
+
+        let config = HttpLoggingConfig {
+            body_enabled: true,
+            max_body_bytes: 128,
+            verbose: true,
+        };
+
+        assert!(should_attempt_response_body_logging(&headers, &config));
+
+        headers.remove(header::CONTENT_LENGTH);
+        assert!(!should_attempt_response_body_logging(&headers, &config));
+    }
+
+    #[test]
+    fn body_logging_is_disabled_outside_development() {
+        let mut headers = header::HeaderMap::new();
+        headers.insert(
+            header::CONTENT_TYPE,
+            header::HeaderValue::from_static("application/json"),
+        );
+        headers.insert(
+            header::CONTENT_LENGTH,
+            header::HeaderValue::from_static("8"),
+        );
+
+        let config = HttpLoggingConfig {
+            body_enabled: false,
+            max_body_bytes: 128,
+            verbose: true,
+        };
+
+        assert!(!should_attempt_request_body_logging(
+            &Method::POST,
+            &headers,
+            &config
+        ));
+    }
+
+    #[test]
+    fn body_logging_does_not_depend_on_verbose_flag() {
+        let mut headers = header::HeaderMap::new();
+        headers.insert(
+            header::CONTENT_TYPE,
+            header::HeaderValue::from_static("application/json"),
+        );
+        headers.insert(
+            header::CONTENT_LENGTH,
+            header::HeaderValue::from_static("8"),
+        );
+
+        let config = HttpLoggingConfig {
+            body_enabled: true,
+            max_body_bytes: 128,
+            verbose: false,
+        };
+
+        assert!(should_attempt_request_body_logging(
+            &Method::POST,
+            &headers,
+            &config
+        ));
+    }
+}

--- a/api/src/core/logger/middleware.rs
+++ b/api/src/core/logger/middleware.rs
@@ -66,7 +66,7 @@ impl Logger {
         let (logged_request_body, request_body_for_next) = if should_attempt_request_body_logging(
             &method, &headers, &config,
         ) {
-            match to_bytes(request_body, usize::MAX).await {
+            match to_bytes(request_body, config.max_body_bytes).await {
                 Ok(bytes) => {
                     let logged_body = parse_redacted_json(&bytes);
                     (logged_body, Body::from(bytes))
@@ -115,7 +115,7 @@ impl Logger {
 
         let (logged_response_body, response_body_for_client) = match to_bytes(
             response_body,
-            usize::MAX,
+            config.max_body_bytes,
         )
         .await
         {

--- a/api/src/core/logger/middleware.rs
+++ b/api/src/core/logger/middleware.rs
@@ -1,7 +1,7 @@
 use std::time::Instant;
 
 use axum::{
-    body::{Body, to_bytes},
+    body::{Body, HttpBody, to_bytes},
     extract::{Request, State},
     http::{
         Method,
@@ -101,14 +101,18 @@ impl Logger {
             return response;
         }
 
-        let response_headers = response.headers().clone();
+        let (response_parts, response_body) = response.into_parts();
+        let response_body_size_hint_upper = response_body.size_hint().upper();
 
-        if !should_attempt_response_body_logging(&response_headers, &config) {
+        if !should_attempt_response_body_logging(
+            &response_parts.headers,
+            response_body_size_hint_upper,
+            &config,
+        ) {
             log_response(request_id, status, duration_ms, None);
-            return response;
+            return Response::from_parts(response_parts, response_body);
         }
 
-        let (response_parts, response_body) = response.into_parts();
         let (logged_response_body, response_body_for_client) = match to_bytes(
             response_body,
             usize::MAX,
@@ -159,7 +163,11 @@ fn should_attempt_request_body_logging(
     }
 }
 
-fn should_attempt_response_body_logging(headers: &HeaderMap, config: &HttpLoggingConfig) -> bool {
+fn should_attempt_response_body_logging(
+    headers: &HeaderMap,
+    body_size_hint_upper: Option<u64>,
+    config: &HttpLoggingConfig,
+) -> bool {
     if !config.body_enabled {
         return false;
     }
@@ -168,7 +176,9 @@ fn should_attempt_response_body_logging(headers: &HeaderMap, config: &HttpLoggin
         return false;
     }
 
-    match content_length(headers) {
+    match content_length(headers).or_else(|| {
+        body_size_hint_upper.and_then(|upper_bound| usize::try_from(upper_bound).ok())
+    }) {
         Some(length) => length <= config.max_body_bytes,
         None => false,
     }
@@ -246,7 +256,7 @@ mod tests {
     }
 
     #[test]
-    fn response_body_logging_requires_known_size_within_limit() {
+    fn response_body_logging_uses_content_length_or_size_hint() {
         let mut headers = header::HeaderMap::new();
         headers.insert(
             header::CONTENT_TYPE,
@@ -263,10 +273,17 @@ mod tests {
             verbose: true,
         };
 
-        assert!(should_attempt_response_body_logging(&headers, &config));
+        assert!(should_attempt_response_body_logging(&headers, None, &config));
 
         headers.remove(header::CONTENT_LENGTH);
-        assert!(!should_attempt_response_body_logging(&headers, &config));
+
+        assert!(should_attempt_response_body_logging(&headers, Some(48), &config));
+        assert!(!should_attempt_response_body_logging(
+            &headers,
+            Some(256),
+            &config
+        ));
+        assert!(!should_attempt_response_body_logging(&headers, None, &config));
     }
 
     #[test]

--- a/api/src/core/logger/mod.rs
+++ b/api/src/core/logger/mod.rs
@@ -1,0 +1,7 @@
+mod backend;
+mod formatting;
+mod middleware;
+mod redaction;
+
+pub use backend::Logger;
+pub use middleware::HttpLoggingConfig;

--- a/api/src/core/logger/redaction.rs
+++ b/api/src/core/logger/redaction.rs
@@ -1,0 +1,150 @@
+use serde_json::{Value, from_slice};
+
+pub(super) fn parse_redacted_json(bytes: &[u8]) -> Option<Value> {
+    if bytes.is_empty() {
+        return None;
+    }
+
+    let mut value = from_slice::<Value>(bytes).ok()?;
+    redact_json_value(&mut value);
+
+    Some(value)
+}
+
+pub(super) fn redact_json_value(value: &mut Value) {
+    match value {
+        Value::Object(map) => {
+            for (key, value) in map.iter_mut() {
+                if is_sensitive_json_key(key) {
+                    *value = Value::String("(hidden)".to_string());
+                } else {
+                    redact_json_value(value);
+                }
+            }
+        }
+        Value::Array(items) => {
+            for item in items {
+                redact_json_value(item);
+            }
+        }
+        _ => {}
+    }
+}
+
+pub(super) fn is_sensitive_json_key(key: &str) -> bool {
+    let key = key.to_ascii_lowercase();
+
+    matches!(
+        key.as_str(),
+        "password"
+            | "confirm"
+            | "token"
+            | "access_token"
+            | "refresh_token"
+            | "auth_code"
+            | "secret"
+            | "api_key"
+    ) || key.contains("token")
+        || key.contains("secret")
+        || key.contains("password")
+}
+
+pub(super) fn sanitize_header_value(name: &str, value: &str) -> String {
+    if is_sensitive_header(name) {
+        "(hidden)".to_string()
+    } else {
+        value.to_string()
+    }
+}
+
+pub(super) fn is_sensitive_header(name: &str) -> bool {
+    let name = name.to_ascii_lowercase();
+
+    matches!(
+        name.as_str(),
+        "authorization" | "cookie" | "set-cookie" | "x-api-key" | "x-auth-token"
+    ) || name.contains("token")
+        || name.contains("secret")
+}
+
+#[cfg(test)]
+mod tests {
+    use serde_json::json;
+
+    use super::{parse_redacted_json, redact_json_value, sanitize_header_value};
+
+    #[test]
+    fn redact_json_masks_sensitive_keys() {
+        let mut value = json!({
+            "password": "secret",
+            "nested": {
+                "auth_code": "123456",
+                "name": "Taylor"
+            }
+        });
+
+        redact_json_value(&mut value);
+
+        assert_eq!(value["password"], "(hidden)");
+        assert_eq!(value["nested"]["auth_code"], "(hidden)");
+        assert_eq!(value["nested"]["name"], "Taylor");
+    }
+
+    #[test]
+    fn redact_json_masks_case_insensitive_and_substring_keys() {
+        let mut value = json!({
+            "Access_Token": "abc",
+            "dbPasswordHash": "hashed",
+            "nested": {
+                "clientSecret": "top-secret",
+                "safe": "visible"
+            },
+            "items": [
+                {
+                    "refresh_token": "token-1"
+                },
+                {
+                    "note": "still-visible"
+                }
+            ]
+        });
+
+        redact_json_value(&mut value);
+
+        assert_eq!(value["Access_Token"], "(hidden)");
+        assert_eq!(value["dbPasswordHash"], "(hidden)");
+        assert_eq!(value["nested"]["clientSecret"], "(hidden)");
+        assert_eq!(value["nested"]["safe"], "visible");
+        assert_eq!(value["items"][0]["refresh_token"], "(hidden)");
+        assert_eq!(value["items"][1]["note"], "still-visible");
+    }
+
+    #[test]
+    fn sanitize_header_value_masks_sensitive_headers() {
+        assert_eq!(
+            sanitize_header_value("Authorization", "Bearer abc"),
+            "(hidden)"
+        );
+        assert_eq!(sanitize_header_value("X-Auth-Token", "abc"), "(hidden)");
+        assert_eq!(
+            sanitize_header_value("X-Client-Secret-Key", "xyz"),
+            "(hidden)"
+        );
+        assert_eq!(sanitize_header_value("X-Request-Id", "123"), "123");
+    }
+
+    #[test]
+    fn parse_redacted_json_returns_none_for_invalid_json() {
+        let value = parse_redacted_json(b"not-json");
+        assert!(value.is_none());
+    }
+
+    #[test]
+    fn parse_redacted_json_redacts_sensitive_fields() {
+        let value = parse_redacted_json(br#"{"password":"abc","name":"Taylor"}"#)
+            .expect("expected valid JSON");
+
+        assert_eq!(value["password"], "(hidden)");
+        assert_eq!(value["name"], "Taylor");
+    }
+}

--- a/api/src/core/mod.rs
+++ b/api/src/core/mod.rs
@@ -1,3 +1,4 @@
 pub mod app;
 pub mod config;
 pub mod error;
+pub mod logger;

--- a/api/src/main.rs
+++ b/api/src/main.rs
@@ -1,10 +1,11 @@
 use gig_log_api::core::app::App;
+use log::error;
 
 #[tokio::main]
 async fn main() {
     let result = App::run().await;
 
     if let Err(error) = result {
-        println!("Error: {:#?}", error);
+        error!("Error: {:#}", error);
     }
 }

--- a/api/src/repo/refresh_token.rs
+++ b/api/src/repo/refresh_token.rs
@@ -1,4 +1,5 @@
 use chrono::{DateTime, Utc};
+use log::warn;
 use sqlx::{FromRow, Pool, Postgres};
 use uuid::Uuid;
 
@@ -70,7 +71,7 @@ impl RefreshTokenRepo {
         .await?;
 
         if result.rows_affected() == 0 {
-            println!(
+            warn!(
                 "Warning: no active refresh token record matched the provided hash during logout"
             );
 

--- a/api/src/repo/refresh_token.rs
+++ b/api/src/repo/refresh_token.rs
@@ -1,5 +1,5 @@
 use chrono::{DateTime, Utc};
-use log::warn;
+use log::error;
 use sqlx::{FromRow, Pool, Postgres};
 use uuid::Uuid;
 
@@ -71,9 +71,7 @@ impl RefreshTokenRepo {
         .await?;
 
         if result.rows_affected() == 0 {
-            warn!(
-                "Warning: no active refresh token record matched the provided hash during logout"
-            );
+            error!("No active refresh token record matched provided hash during logout");
 
             return Ok(false);
         }

--- a/api/src/repo/refresh_token.rs
+++ b/api/src/repo/refresh_token.rs
@@ -1,5 +1,5 @@
 use chrono::{DateTime, Utc};
-use log::error;
+use log::warn;
 use sqlx::{FromRow, Pool, Postgres};
 use uuid::Uuid;
 
@@ -71,7 +71,7 @@ impl RefreshTokenRepo {
         .await?;
 
         if result.rows_affected() == 0 {
-            error!("No active refresh token record matched provided hash during logout");
+            warn!("No active refresh token record matched provided hash during logout");
 
             return Ok(false);
         }

--- a/api/src/routes/app.rs
+++ b/api/src/routes/app.rs
@@ -1,12 +1,16 @@
 use axum::{
     Router,
     http::{HeaderName, Method},
+    middleware,
 };
 use sqlx::{Pool, Postgres};
 use tower_http::cors::{AllowOrigin, CorsLayer};
 
 use crate::{
-    core::config::Config,
+    core::{
+        config::Config,
+        logger::{HttpLoggingConfig, Logger},
+    },
     email::client::EmailClient,
     routes::{auth::AuthRouter, health::HealthRouter},
 };
@@ -22,6 +26,12 @@ pub struct AppRouter;
 
 impl AppRouter {
     pub fn new(state: AppState) -> Router {
+        let http_logging_config = HttpLoggingConfig::new(
+            state.config.is_http_body_logging_enabled(),
+            state.config.log_http_max_body,
+            state.config.log_verbose,
+        );
+
         let web_origin = state.config.web_origin.parse().unwrap_or_else(|_| {
             "http://localhost:3000"
                 .parse()
@@ -46,6 +56,10 @@ impl AppRouter {
         Router::new()
             .nest("/health", HealthRouter::new())
             .nest("/auth", AuthRouter::new())
+            .layer(middleware::from_fn_with_state(
+                http_logging_config,
+                Logger::log_request_and_response,
+            ))
             .layer(cors)
             .with_state(state)
     }

--- a/api/src/routes/app.rs
+++ b/api/src/routes/app.rs
@@ -3,6 +3,7 @@ use axum::{
     http::{HeaderName, Method},
     middleware,
 };
+use log::error;
 use sqlx::{Pool, Postgres};
 use tower_http::cors::{AllowOrigin, CorsLayer};
 
@@ -32,7 +33,12 @@ impl AppRouter {
             state.config.log_verbose,
         );
 
-        let web_origin = state.config.web_origin.parse().unwrap_or_else(|_| {
+        let web_origin = state.config.web_origin.parse().unwrap_or_else(|error| {
+            error!(
+                "Failed to parse WEB_ORIGIN '{}': {}; using http://localhost:3000 instead",
+                state.config.web_origin, error
+            );
+
             "http://localhost:3000"
                 .parse()
                 .expect("default localhost origin should always be valid")

--- a/common/Cargo.toml
+++ b/common/Cargo.toml
@@ -9,6 +9,7 @@ validation = ["dep:validator"]
 
 [dependencies]
 chrono = { version = "0.4.44", features = ["serde"] }
+log = "0.4.28"
 serde = { version = "1.0.228", features = ["derive"] }
 serde_json = "1.0.149"
 uuid = { version = "1.21.0", features = ["serde"] }

--- a/common/src/lib.rs
+++ b/common/src/lib.rs
@@ -1,2 +1,3 @@
+pub mod logging;
 pub mod models;
 pub mod validators;

--- a/common/src/logging.rs
+++ b/common/src/logging.rs
@@ -1,0 +1,64 @@
+use log::{Level, LevelFilter};
+
+pub use log::{debug, error, info, trace, warn};
+
+pub fn parse_level_filter(log_level: &str) -> LevelFilter {
+    match log_level.trim().to_ascii_lowercase().as_str() {
+        "off" => LevelFilter::Off,
+        "error" => LevelFilter::Error,
+        "warn" => LevelFilter::Warn,
+        "info" => LevelFilter::Info,
+        "debug" => LevelFilter::Debug,
+        "trace" => LevelFilter::Trace,
+        _ => LevelFilter::Info,
+    }
+}
+
+pub fn level_for_logger(level_filter: LevelFilter) -> Level {
+    match level_filter {
+        LevelFilter::Off | LevelFilter::Error => Level::Error,
+        LevelFilter::Warn => Level::Warn,
+        LevelFilter::Info => Level::Info,
+        LevelFilter::Debug => Level::Debug,
+        LevelFilter::Trace => Level::Trace,
+    }
+}
+
+pub fn is_off(level_filter: LevelFilter) -> bool {
+    matches!(level_filter, LevelFilter::Off)
+}
+
+#[cfg(test)]
+mod tests {
+    use log::{Level, LevelFilter};
+
+    use super::{is_off, level_for_logger, parse_level_filter};
+
+    #[test]
+    fn parse_level_filter_handles_expected_values() {
+        assert_eq!(parse_level_filter("off"), LevelFilter::Off);
+        assert_eq!(parse_level_filter("error"), LevelFilter::Error);
+        assert_eq!(parse_level_filter("warn"), LevelFilter::Warn);
+        assert_eq!(parse_level_filter("info"), LevelFilter::Info);
+        assert_eq!(parse_level_filter("debug"), LevelFilter::Debug);
+        assert_eq!(parse_level_filter("trace"), LevelFilter::Trace);
+        assert_eq!(parse_level_filter("invalid"), LevelFilter::Info);
+    }
+
+    #[test]
+    fn parse_level_filter_is_case_and_whitespace_insensitive() {
+        assert_eq!(parse_level_filter(" DEBUG "), LevelFilter::Debug);
+    }
+
+    #[test]
+    fn level_for_logger_maps_off_to_error_for_init() {
+        assert_eq!(level_for_logger(LevelFilter::Off), Level::Error);
+        assert_eq!(level_for_logger(LevelFilter::Info), Level::Info);
+    }
+
+    #[test]
+    fn is_off_detects_only_off() {
+        assert!(is_off(LevelFilter::Off));
+        assert!(!is_off(LevelFilter::Error));
+    }
+}

--- a/dev-tools/Cargo.toml
+++ b/dev-tools/Cargo.toml
@@ -8,6 +8,7 @@ name = "gig-log-dev-tools"
 path = "src/main.rs"
 
 [dependencies]
+axum = "0.8.8"
 clap = { version = "4", features = ["derive"] }
 ratatui = { version = "0.29", features = ["unstable-rendered-line-info"] }
 crossterm = "0.28"

--- a/dev-tools/src/dev/mod.rs
+++ b/dev-tools/src/dev/mod.rs
@@ -3,6 +3,7 @@ mod process;
 mod tui;
 mod ui;
 mod watcher;
+mod web_log_relay;
 
 use std::time::Duration;
 
@@ -100,6 +101,45 @@ async fn run_orchestrator(
         log_senders.push((service, spawn_log_forwarder(&tui_tx)));
     }
 
+    let system_log_tx = match log_senders
+        .iter()
+        .find(|(service, _)| *service == Service::System)
+        .map(|(_, tx)| tx.clone())
+    {
+        Some(tx) => tx,
+        None => return Ok(()),
+    };
+
+    let mut web_log_relay = match log_senders
+        .iter()
+        .find(|(service, _)| *service == Service::Web)
+        .map(|(_, tx)| tx.clone())
+    {
+        Some(web_log_tx) => match web_log_relay::start(web_log_tx).await {
+            Ok(relay) => {
+                system_log(
+                    &system_log_tx,
+                    format!(
+                        "Web log relay active at {} (proxy path {})",
+                        web_log_relay::WEB_LOG_RELAY_ADDR,
+                        web_log_relay::WEB_LOG_RELAY_PROXY_PATH
+                    ),
+                )
+                .await;
+                Some(relay)
+            }
+            Err(error) => {
+                system_log(
+                    &system_log_tx,
+                    format!("Failed to start web log relay: {error}"),
+                )
+                .await;
+                None
+            }
+        },
+        None => None,
+    };
+
     let _miniserve = start_docs_prerequisites().await?;
     if let Some(docs_tx) = log_senders
         .iter()
@@ -143,15 +183,6 @@ async fn run_orchestrator(
             }
         });
     }
-
-    let system_log_tx = match log_senders
-        .iter()
-        .find(|(service, _)| *service == Service::System)
-        .map(|(_, tx)| tx.clone())
-    {
-        Some(tx) => tx,
-        None => return Ok(()),
-    };
 
     run_initial_docs_after_startup(&tui_tx, &system_log_tx, &log_senders, &mut trunk_event_rx)
         .await;
@@ -209,6 +240,10 @@ async fn run_orchestrator(
 
     for mut proc in processes {
         proc.shutdown_fast().await;
+    }
+
+    if let Some(relay) = web_log_relay.take() {
+        relay.shutdown().await;
     }
 
     Ok(())

--- a/dev-tools/src/dev/mod.rs
+++ b/dev-tools/src/dev/mod.rs
@@ -153,13 +153,8 @@ async fn run_orchestrator(
         None => return Ok(()),
     };
 
-    run_initial_docs_after_startup(
-        &tui_tx,
-        &system_log_tx,
-        &log_senders,
-        &mut trunk_event_rx,
-    )
-    .await;
+    run_initial_docs_after_startup(&tui_tx, &system_log_tx, &log_senders, &mut trunk_event_rx)
+        .await;
 
     let mut watch_stream = watcher::start(&WATCH_PATHS)?;
 
@@ -357,8 +352,11 @@ async fn execute_batch(
         if docs_after_api_restart {
             match wait_for_api_ready().await {
                 Ok(()) => {
-                    system_log(system_tx, "API is ready. Running docs generation...".to_string())
-                        .await;
+                    system_log(
+                        system_tx,
+                        "API is ready. Running docs generation...".to_string(),
+                    )
+                    .await;
                 }
                 Err(error) => {
                     system_log(
@@ -663,9 +661,7 @@ async fn reset_docs_output_dir() -> Result<()> {
 
 #[cfg(test)]
 mod tests {
-    use super::{
-        TrunkEvent, drain_trunk_events, parse_trunk_event, wait_for_web_build,
-    };
+    use super::{TrunkEvent, drain_trunk_events, parse_trunk_event, wait_for_web_build};
     use tokio::sync::mpsc;
 
     #[test]

--- a/dev-tools/src/dev/process.rs
+++ b/dev-tools/src/dev/process.rs
@@ -170,10 +170,10 @@ async fn read_lines<R: tokio::io::AsyncRead + Unpin>(
     tx: mpsc::Sender<LogEntry>,
 ) {
     let mut lines = BufReader::new(reader).lines();
-    let mut pending_ansi_prefix = String::new();
+    let mut active_ansi_prefix = String::new();
 
     while let Ok(Some(line)) = lines.next_line().await {
-        let Some(line) = normalize_ansi_for_tui(line, &mut pending_ansi_prefix) else {
+        let Some(line) = normalize_ansi_for_tui(line, &mut active_ansi_prefix) else {
             continue;
         };
 
@@ -183,27 +183,84 @@ async fn read_lines<R: tokio::io::AsyncRead + Unpin>(
     }
 }
 
-fn normalize_ansi_for_tui(line: String, pending_ansi_prefix: &mut String) -> Option<String> {
+fn normalize_ansi_for_tui(line: String, active_ansi_prefix: &mut String) -> Option<String> {
     if is_ansi_control_only_line(&line) {
-        if line_contains_ansi_reset(&line) {
-            pending_ansi_prefix.clear();
-        } else {
-            pending_ansi_prefix.push_str(&line);
-        }
+        update_active_ansi_prefix(&line, active_ansi_prefix);
 
         return Some(String::new());
     }
 
-    if pending_ansi_prefix.is_empty() {
+    if line.is_empty() {
         return Some(line);
     }
 
-    let mut normalized = String::with_capacity(pending_ansi_prefix.len() + line.len());
-    normalized.push_str(pending_ansi_prefix);
+    let should_prepend_active_prefix =
+        !active_ansi_prefix.is_empty() && !starts_with_ansi_sequence(&line);
+    let prefix_for_line = if should_prepend_active_prefix {
+        Some(active_ansi_prefix.clone())
+    } else {
+        None
+    };
+
+    update_active_ansi_prefix(&line, active_ansi_prefix);
+
+    let Some(prefix_for_line) = prefix_for_line else {
+        return Some(line);
+    };
+
+    let mut normalized = String::with_capacity(prefix_for_line.len() + line.len());
+    normalized.push_str(&prefix_for_line);
     normalized.push_str(&line);
-    pending_ansi_prefix.clear();
 
     Some(normalized)
+}
+
+fn starts_with_ansi_sequence(line: &str) -> bool {
+    line.as_bytes().starts_with(b"\x1b[")
+}
+
+fn update_active_ansi_prefix(line: &str, active_ansi_prefix: &mut String) {
+    if starts_with_ansi_sequence(line) {
+        active_ansi_prefix.clear();
+    }
+
+    let bytes = line.as_bytes();
+    let mut index = 0;
+
+    while index + 1 < bytes.len() {
+        if bytes[index] != b'\x1b' || bytes[index + 1] != b'[' {
+            index += 1;
+            continue;
+        }
+
+        let sequence_start = index;
+        index += 2;
+
+        while index < bytes.len() {
+            let byte = bytes[index];
+            index += 1;
+
+            if (b'@'..=b'~').contains(&byte) {
+                let sequence = &line[sequence_start..index];
+
+                if ansi_sequence_is_reset(sequence) {
+                    active_ansi_prefix.clear();
+                } else if ansi_sequence_is_sgr(sequence) {
+                    active_ansi_prefix.push_str(sequence);
+                }
+
+                break;
+            }
+        }
+    }
+}
+
+fn ansi_sequence_is_reset(sequence: &str) -> bool {
+    sequence == "\u{1b}[0m" || sequence == "\u{1b}[m"
+}
+
+fn ansi_sequence_is_sgr(sequence: &str) -> bool {
+    sequence.ends_with('m')
 }
 
 fn is_ansi_control_only_line(line: &str) -> bool {
@@ -233,10 +290,6 @@ fn strip_ansi_sequences(line: &str) -> String {
     output
 }
 
-fn line_contains_ansi_reset(line: &str) -> bool {
-    line.contains("\u{1b}[0m") || line.contains("\u{1b}[m")
-}
-
 pub fn check_requirements() -> Result<()> {
     for binary in ["trunk", "miniserve"] {
         if std::process::Command::new("which")
@@ -259,31 +312,58 @@ mod tests {
     use super::normalize_ansi_for_tui;
 
     #[test]
-    fn ansi_control_prefix_is_applied_to_next_log_line() {
-        let mut pending_ansi_prefix = String::new();
+    fn ansi_control_prefix_is_applied_until_reset() {
+        let mut active_ansi_prefix = String::new();
 
-        let first = normalize_ansi_for_tui("\u{1b}[34m".to_string(), &mut pending_ansi_prefix);
+        let first = normalize_ansi_for_tui("\u{1b}[34m".to_string(), &mut active_ansi_prefix);
         assert_eq!(first, Some(String::new()));
-        assert_eq!(pending_ansi_prefix, "\u{1b}[34m");
+        assert_eq!(active_ansi_prefix, "\u{1b}[34m");
 
-        let second = normalize_ansi_for_tui("hello world".to_string(), &mut pending_ansi_prefix);
-        assert_eq!(second, Some("\u{1b}[34mhello world".to_string()));
-        assert!(pending_ansi_prefix.is_empty());
+        let second = normalize_ansi_for_tui("hello".to_string(), &mut active_ansi_prefix);
+        assert_eq!(second, Some("\u{1b}[34mhello".to_string()));
+        assert_eq!(active_ansi_prefix, "\u{1b}[34m");
+
+        let third = normalize_ansi_for_tui("world".to_string(), &mut active_ansi_prefix);
+        assert_eq!(third, Some("\u{1b}[34mworld".to_string()));
+        assert_eq!(active_ansi_prefix, "\u{1b}[34m");
+
+        let reset = normalize_ansi_for_tui("\u{1b}[0m".to_string(), &mut active_ansi_prefix);
+        assert_eq!(reset, Some(String::new()));
+        assert!(active_ansi_prefix.is_empty());
+
+        let after_reset =
+            normalize_ansi_for_tui("after reset".to_string(), &mut active_ansi_prefix);
+        assert_eq!(after_reset, Some("after reset".to_string()));
     }
 
     #[test]
     fn ansi_reset_line_clears_pending_prefix() {
-        let mut pending_ansi_prefix = "\u{1b}[34m".to_string();
+        let mut active_ansi_prefix = "\u{1b}[34m".to_string();
 
-        let normalized = normalize_ansi_for_tui("\u{1b}[0m".to_string(), &mut pending_ansi_prefix);
+        let normalized = normalize_ansi_for_tui("\u{1b}[0m".to_string(), &mut active_ansi_prefix);
         assert_eq!(normalized, Some(String::new()));
-        assert!(pending_ansi_prefix.is_empty());
+        assert!(active_ansi_prefix.is_empty());
+    }
+
+    #[test]
+    fn inline_reset_clears_active_prefix_for_following_lines() {
+        let mut active_ansi_prefix = "\u{1b}[31m".to_string();
+
+        let first = normalize_ansi_for_tui(
+            "line one\u{1b}[0m plain".to_string(),
+            &mut active_ansi_prefix,
+        );
+        assert_eq!(first, Some("\u{1b}[31mline one\u{1b}[0m plain".to_string()));
+        assert!(active_ansi_prefix.is_empty());
+
+        let second = normalize_ansi_for_tui("line two".to_string(), &mut active_ansi_prefix);
+        assert_eq!(second, Some("line two".to_string()));
     }
 
     #[test]
     fn plain_empty_line_is_preserved() {
-        let mut pending_ansi_prefix = String::new();
-        let normalized = normalize_ansi_for_tui(String::new(), &mut pending_ansi_prefix);
+        let mut active_ansi_prefix = String::new();
+        let normalized = normalize_ansi_for_tui(String::new(), &mut active_ansi_prefix);
         assert_eq!(normalized, Some(String::new()));
     }
 }

--- a/dev-tools/src/dev/process.rs
+++ b/dev-tools/src/dev/process.rs
@@ -170,11 +170,71 @@ async fn read_lines<R: tokio::io::AsyncRead + Unpin>(
     tx: mpsc::Sender<LogEntry>,
 ) {
     let mut lines = BufReader::new(reader).lines();
+    let mut pending_ansi_prefix = String::new();
+
     while let Ok(Some(line)) = lines.next_line().await {
+        let Some(line) = normalize_ansi_for_tui(line, &mut pending_ansi_prefix) else {
+            continue;
+        };
+
         if tx.send(LogEntry { service, line }).await.is_err() {
             break;
         }
     }
+}
+
+fn normalize_ansi_for_tui(line: String, pending_ansi_prefix: &mut String) -> Option<String> {
+    if is_ansi_control_only_line(&line) {
+        if line_contains_ansi_reset(&line) {
+            pending_ansi_prefix.clear();
+        } else {
+            pending_ansi_prefix.push_str(&line);
+        }
+
+        return Some(String::new());
+    }
+
+    if pending_ansi_prefix.is_empty() {
+        return Some(line);
+    }
+
+    let mut normalized = String::with_capacity(pending_ansi_prefix.len() + line.len());
+    normalized.push_str(pending_ansi_prefix);
+    normalized.push_str(&line);
+    pending_ansi_prefix.clear();
+
+    Some(normalized)
+}
+
+fn is_ansi_control_only_line(line: &str) -> bool {
+    line.contains('\u{1b}') && strip_ansi_sequences(line).trim().is_empty()
+}
+
+fn strip_ansi_sequences(line: &str) -> String {
+    let mut output = String::with_capacity(line.len());
+    let mut chars = line.chars().peekable();
+
+    while let Some(ch) = chars.next() {
+        if ch == '\u{1b}' && matches!(chars.peek(), Some('[')) {
+            let _ = chars.next();
+
+            for seq_char in chars.by_ref() {
+                if ('@'..='~').contains(&seq_char) {
+                    break;
+                }
+            }
+
+            continue;
+        }
+
+        output.push(ch);
+    }
+
+    output
+}
+
+fn line_contains_ansi_reset(line: &str) -> bool {
+    line.contains("\u{1b}[0m") || line.contains("\u{1b}[m")
 }
 
 pub fn check_requirements() -> Result<()> {
@@ -192,4 +252,38 @@ pub fn check_requirements() -> Result<()> {
     }
 
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::normalize_ansi_for_tui;
+
+    #[test]
+    fn ansi_control_prefix_is_applied_to_next_log_line() {
+        let mut pending_ansi_prefix = String::new();
+
+        let first = normalize_ansi_for_tui("\u{1b}[34m".to_string(), &mut pending_ansi_prefix);
+        assert_eq!(first, Some(String::new()));
+        assert_eq!(pending_ansi_prefix, "\u{1b}[34m");
+
+        let second = normalize_ansi_for_tui("hello world".to_string(), &mut pending_ansi_prefix);
+        assert_eq!(second, Some("\u{1b}[34mhello world".to_string()));
+        assert!(pending_ansi_prefix.is_empty());
+    }
+
+    #[test]
+    fn ansi_reset_line_clears_pending_prefix() {
+        let mut pending_ansi_prefix = "\u{1b}[34m".to_string();
+
+        let normalized = normalize_ansi_for_tui("\u{1b}[0m".to_string(), &mut pending_ansi_prefix);
+        assert_eq!(normalized, Some(String::new()));
+        assert!(pending_ansi_prefix.is_empty());
+    }
+
+    #[test]
+    fn plain_empty_line_is_preserved() {
+        let mut pending_ansi_prefix = String::new();
+        let normalized = normalize_ansi_for_tui(String::new(), &mut pending_ansi_prefix);
+        assert_eq!(normalized, Some(String::new()));
+    }
 }

--- a/dev-tools/src/dev/process.rs
+++ b/dev-tools/src/dev/process.rs
@@ -6,7 +6,10 @@ use tokio::io::{AsyncBufReadExt, BufReader};
 use tokio::process::{Child, Command};
 use tokio::sync::mpsc;
 
-use super::log_store::{LogEntry, Service};
+use super::{
+    log_store::{LogEntry, Service},
+    web_log_relay::{WEB_LOG_RELAY_BACKEND_URL, WEB_LOG_RELAY_PROXY_PATH},
+};
 
 pub struct ServiceProcess {
     pub service: Service,
@@ -159,7 +162,17 @@ fn service_command(
 ) -> Result<(&'static str, Vec<&'static str>, Option<&'static str>)> {
     match service {
         Service::Api => Ok(("cargo", vec!["run", "-p", "gig-log-api"], None)),
-        Service::Web => Ok(("trunk", vec!["serve"], Some("web/"))),
+        Service::Web => Ok((
+            "trunk",
+            vec![
+                "serve",
+                "--proxy-rewrite",
+                WEB_LOG_RELAY_PROXY_PATH,
+                "--proxy-backend",
+                WEB_LOG_RELAY_BACKEND_URL,
+            ],
+            Some("web/"),
+        )),
         _ => anyhow::bail!("{} is not a long-running service", service.label()),
     }
 }
@@ -309,7 +322,9 @@ pub fn check_requirements() -> Result<()> {
 
 #[cfg(test)]
 mod tests {
-    use super::normalize_ansi_for_tui;
+    use super::{normalize_ansi_for_tui, service_command};
+    use crate::dev::log_store::Service;
+    use crate::dev::web_log_relay::{WEB_LOG_RELAY_BACKEND_URL, WEB_LOG_RELAY_PROXY_PATH};
 
     #[test]
     fn ansi_control_prefix_is_applied_until_reset() {
@@ -365,5 +380,21 @@ mod tests {
         let mut active_ansi_prefix = String::new();
         let normalized = normalize_ansi_for_tui(String::new(), &mut active_ansi_prefix);
         assert_eq!(normalized, Some(String::new()));
+    }
+
+    #[test]
+    fn web_service_uses_relay_proxy() {
+        let (cmd, args, working_dir) = service_command(Service::Web).expect("web command");
+
+        assert_eq!(cmd, "trunk");
+        assert_eq!(working_dir, Some("web/"));
+        assert!(
+            args.windows(2)
+                .any(|window| { window == ["--proxy-rewrite", WEB_LOG_RELAY_PROXY_PATH] })
+        );
+        assert!(
+            args.windows(2)
+                .any(|window| { window == ["--proxy-backend", WEB_LOG_RELAY_BACKEND_URL] })
+        );
     }
 }

--- a/dev-tools/src/dev/ui.rs
+++ b/dev-tools/src/dev/ui.rs
@@ -1,9 +1,9 @@
 use ansi_to_tui::IntoText as _;
+use ratatui::Frame;
 use ratatui::layout::{Constraint, Layout, Rect};
 use ratatui::style::{Color, Modifier, Style};
 use ratatui::text::{Line, Span};
 use ratatui::widgets::{Block, Borders, Paragraph, Wrap};
-use ratatui::Frame;
 
 use super::log_store::{LogEntry, Service};
 

--- a/dev-tools/src/dev/web_log_relay.rs
+++ b/dev-tools/src/dev/web_log_relay.rs
@@ -140,11 +140,10 @@ async fn relay_log(
 fn read_verbose_from_env() -> bool {
     std::env::var("LOG_VERBOSE")
         .ok()
-        .map(|value| {
-            matches!(
-                value.trim().to_ascii_lowercase().as_str(),
-                "true" | "1" | "yes" | "on"
-            )
+        .map(|value| match value.trim().to_ascii_lowercase().as_str() {
+            "true" | "1" | "yes" | "on" => true,
+            "false" | "0" | "no" | "off" => false,
+            _ => true,
         })
         .unwrap_or(true)
 }

--- a/dev-tools/src/dev/web_log_relay.rs
+++ b/dev-tools/src/dev/web_log_relay.rs
@@ -1,0 +1,276 @@
+use std::sync::Arc;
+
+use anyhow::{Context, Result};
+use axum::{Json, Router, extract::State, http::StatusCode, routing::post};
+use serde::Deserialize;
+use tokio::{
+    net::TcpListener,
+    sync::{Mutex, mpsc, oneshot},
+    task::JoinHandle,
+};
+
+use super::log_store::{LogEntry, Service};
+
+pub const WEB_LOG_RELAY_ADDR: &str = "127.0.0.1:9777";
+pub const WEB_LOG_RELAY_BACKEND_URL: &str = "http://127.0.0.1:9777";
+pub const WEB_LOG_RELAY_PROXY_PATH: &str = "/_giglog/web-log";
+
+const ANSI_BLUE: &str = "\x1b[34m";
+const ANSI_RED: &str = "\x1b[31m";
+const ANSI_YELLOW: &str = "\x1b[33m";
+const ANSI_MAGENTA: &str = "\x1b[35m";
+const ANSI_PURPLE: &str = "\x1b[35m";
+const ANSI_CLEAR: &str = "\x1b[0m";
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum WebLogLevel {
+    Error,
+    Warn,
+    Info,
+    Debug,
+    Trace,
+}
+
+impl WebLogLevel {
+    fn parse(raw: &str) -> Self {
+        match raw.trim().to_ascii_lowercase().as_str() {
+            "error" => Self::Error,
+            "warn" | "warning" => Self::Warn,
+            "debug" => Self::Debug,
+            "trace" => Self::Trace,
+            "info" => Self::Info,
+            _ => Self::Info,
+        }
+    }
+}
+
+#[derive(Debug, Clone, Deserialize)]
+struct RelayLogPayload {
+    level: String,
+    message: String,
+    target: Option<String>,
+    file: Option<String>,
+    line: Option<u32>,
+}
+
+#[derive(Clone)]
+struct RelayState {
+    web_log_tx: mpsc::Sender<LogEntry>,
+    verbose: bool,
+    emit_lock: Arc<Mutex<()>>,
+}
+
+pub struct WebLogRelay {
+    shutdown_tx: Option<oneshot::Sender<()>>,
+    task: JoinHandle<()>,
+}
+
+impl WebLogRelay {
+    pub async fn shutdown(mut self) {
+        if let Some(tx) = self.shutdown_tx.take() {
+            let _ = tx.send(());
+        }
+        let _ = self.task.await;
+    }
+}
+
+pub async fn start(web_log_tx: mpsc::Sender<LogEntry>) -> Result<WebLogRelay> {
+    let listener = TcpListener::bind(WEB_LOG_RELAY_ADDR)
+        .await
+        .with_context(|| format!("Failed to bind web log relay on {WEB_LOG_RELAY_ADDR}"))?;
+
+    let state = RelayState {
+        web_log_tx,
+        verbose: read_verbose_from_env(),
+        emit_lock: Arc::new(Mutex::new(())),
+    };
+
+    let app = Router::new()
+        .route("/", post(relay_log))
+        .route(WEB_LOG_RELAY_PROXY_PATH, post(relay_log))
+        .with_state(state.clone());
+
+    let (shutdown_tx, shutdown_rx) = oneshot::channel::<()>();
+    let task = tokio::spawn(async move {
+        let server = axum::serve(listener, app).with_graceful_shutdown(async {
+            let _ = shutdown_rx.await;
+        });
+
+        if let Err(error) = server.await {
+            let _ = state
+                .web_log_tx
+                .send(LogEntry {
+                    service: Service::System,
+                    line: format!("Web log relay stopped unexpectedly: {error}"),
+                })
+                .await;
+        }
+    });
+
+    Ok(WebLogRelay {
+        shutdown_tx: Some(shutdown_tx),
+        task,
+    })
+}
+
+async fn relay_log(
+    State(state): State<RelayState>,
+    Json(payload): Json<RelayLogPayload>,
+) -> StatusCode {
+    let _emit_guard = state.emit_lock.lock().await;
+    let formatted = format_relay_line(&payload, state.verbose);
+
+    for line in split_formatted_lines(&formatted) {
+        if state
+            .web_log_tx
+            .send(LogEntry {
+                service: Service::Web,
+                line,
+            })
+            .await
+            .is_err()
+        {
+            return StatusCode::SERVICE_UNAVAILABLE;
+        }
+    }
+
+    StatusCode::NO_CONTENT
+}
+
+fn read_verbose_from_env() -> bool {
+    std::env::var("LOG_VERBOSE")
+        .ok()
+        .map(|value| {
+            matches!(
+                value.trim().to_ascii_lowercase().as_str(),
+                "true" | "1" | "yes" | "on"
+            )
+        })
+        .unwrap_or(true)
+}
+
+fn format_relay_line(payload: &RelayLogPayload, verbose: bool) -> String {
+    let level = WebLogLevel::parse(&payload.level);
+    let message = payload.message.trim_end().to_string();
+    let file = payload
+        .file
+        .as_deref()
+        .map(extract_after_src)
+        .filter(|value| !value.is_empty())
+        .or_else(|| payload.target.clone())
+        .unwrap_or_default();
+    let line_number = payload
+        .line
+        .map(|line| line.to_string())
+        .unwrap_or_default();
+
+    if !verbose {
+        return format_non_verbose(level, &message);
+    }
+
+    match level {
+        WebLogLevel::Info => format!("\n{ANSI_BLUE}{message}{ANSI_CLEAR}"),
+        WebLogLevel::Error => format_error_like("Error", ANSI_RED, &file, &line_number, &message),
+        WebLogLevel::Debug => {
+            format_error_like("Debug", ANSI_YELLOW, &file, &line_number, &message)
+        }
+        WebLogLevel::Warn | WebLogLevel::Trace => format!(
+            "\n{ANSI_PURPLE}File: {file}{ANSI_CLEAR}\n{ANSI_PURPLE}Line Number: {line_number}{ANSI_CLEAR}\n{message}"
+        ),
+    }
+}
+
+fn format_non_verbose(level: WebLogLevel, message: &str) -> String {
+    match level {
+        WebLogLevel::Error => format!("{ANSI_RED}[ERROR] {message}{ANSI_CLEAR}"),
+        WebLogLevel::Warn => format!("{ANSI_YELLOW}[WARN] {message}{ANSI_CLEAR}"),
+        WebLogLevel::Info => message.to_string(),
+        WebLogLevel::Debug => format!("{ANSI_BLUE}[DEBUG] {message}{ANSI_CLEAR}"),
+        WebLogLevel::Trace => format!("{ANSI_MAGENTA}[TRACE] {message}{ANSI_CLEAR}"),
+    }
+}
+
+fn format_error_like(
+    title: &str,
+    color: &str,
+    file: &str,
+    line_number: &str,
+    message: &str,
+) -> String {
+    let hashtags = "######";
+    format!(
+        "\n{color}{hashtags} {title} {hashtags}{ANSI_CLEAR}\n{color}File: {file}{ANSI_CLEAR}\n{color}Line Number: {line_number}{ANSI_CLEAR}\n\n{color}{message}{ANSI_CLEAR}"
+    )
+}
+
+fn split_formatted_lines(formatted: &str) -> Vec<String> {
+    formatted.split('\n').map(str::to_string).collect()
+}
+
+fn extract_after_src(path: &str) -> String {
+    let src_prefix = "src/";
+    if let Some(start_index) = path.find(src_prefix) {
+        return path[start_index + src_prefix.len()..].to_string();
+    }
+
+    path.to_string()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{
+        RelayLogPayload, WebLogLevel, extract_after_src, format_non_verbose, format_relay_line,
+        split_formatted_lines,
+    };
+
+    #[test]
+    fn parse_level_defaults_to_info() {
+        assert_eq!(WebLogLevel::parse("wat"), WebLogLevel::Info);
+        assert_eq!(WebLogLevel::parse("warn"), WebLogLevel::Warn);
+    }
+
+    #[test]
+    fn extract_after_src_returns_relative_suffix() {
+        assert_eq!(
+            extract_after_src("/tmp/project/src/main.rs"),
+            "main.rs".to_string()
+        );
+    }
+
+    #[test]
+    fn non_verbose_error_uses_api_style_prefix() {
+        let formatted = format_non_verbose(WebLogLevel::Error, "boom");
+        assert!(formatted.contains("[ERROR] boom"));
+        assert!(formatted.contains("\u{1b}[31m"));
+    }
+
+    #[test]
+    fn verbose_debug_uses_banner_format() {
+        let payload = RelayLogPayload {
+            level: "debug".to_string(),
+            message: "test log".to_string(),
+            target: Some("app::module".to_string()),
+            file: Some("/tmp/project/src/app/mod.rs".to_string()),
+            line: Some(42),
+        };
+
+        let formatted = format_relay_line(&payload, true);
+        assert!(formatted.contains("###### Debug ######"));
+        assert!(formatted.contains("File: app/mod.rs"));
+        assert!(formatted.contains("Line Number: 42"));
+        assert!(formatted.contains("test log"));
+    }
+
+    #[test]
+    fn split_formatted_lines_preserves_blank_lines() {
+        let formatted = "\n\x1b[31m###### Error ######\x1b[0m\n\n\x1b[31mboom\x1b[0m\n";
+        let lines = split_formatted_lines(formatted);
+
+        assert_eq!(lines.len(), 5);
+        assert_eq!(lines[0], "");
+        assert!(lines[1].contains("###### Error ######"));
+        assert_eq!(lines[2], "");
+        assert!(lines[3].contains("boom"));
+        assert_eq!(lines[4], "");
+    }
+}

--- a/web/Cargo.toml
+++ b/web/Cargo.toml
@@ -4,5 +4,9 @@ version = "0.1.0"
 edition = "2024"
 
 [dependencies]
+gloo-net = "0.6.0"
 gig-log-common = { path = "../common" }
 leptos = { version = "0.8.16", features = ["csr"] }
+log = "0.4.28"
+serde = { version = "1.0.228", features = ["derive"] }
+wasm-bindgen-futures = "0.4"

--- a/web/src/logging.rs
+++ b/web/src/logging.rs
@@ -1,0 +1,124 @@
+use std::cell::{Cell, RefCell};
+use std::collections::VecDeque;
+
+use gig_log_common::logging::{is_off, parse_level_filter};
+use gloo_net::http::Request;
+use log::{LevelFilter, Log, Metadata, Record, SetLoggerError};
+use serde::Serialize;
+use wasm_bindgen_futures::spawn_local;
+
+const WEB_LOG_RELAY_ENDPOINT: &str = "/_giglog/web-log";
+
+#[derive(Debug, Clone, Copy)]
+pub struct WebLoggerConfig {
+    pub configured_level: &'static str,
+    pub level_filter: LevelFilter,
+}
+
+struct WebRelayLogger;
+
+static WEB_RELAY_LOGGER: WebRelayLogger = WebRelayLogger;
+
+thread_local! {
+    static RELAY_QUEUE: RefCell<VecDeque<RelayLogPayload>> = RefCell::new(VecDeque::new());
+    static RELAY_SENDING: Cell<bool> = const { Cell::new(false) };
+}
+
+#[derive(Debug, Serialize)]
+struct RelayLogPayload {
+    level: String,
+    message: String,
+    target: Option<String>,
+    file: Option<String>,
+    line: Option<u32>,
+}
+
+pub fn init_web_logging(default_level: &'static str) -> Result<WebLoggerConfig, SetLoggerError> {
+    let configured_level = option_env!("WEB_LOG_LEVEL").unwrap_or(default_level);
+    let level_filter = parse_level_filter(configured_level);
+
+    log::set_max_level(level_filter);
+
+    if is_off(level_filter) {
+        return Ok(WebLoggerConfig {
+            configured_level,
+            level_filter,
+        });
+    }
+
+    log::set_logger(&WEB_RELAY_LOGGER)?;
+
+    Ok(WebLoggerConfig {
+        configured_level,
+        level_filter,
+    })
+}
+
+impl Log for WebRelayLogger {
+    fn enabled(&self, _metadata: &Metadata<'_>) -> bool {
+        true
+    }
+
+    fn log(&self, record: &Record<'_>) {
+        if !self.enabled(record.metadata()) {
+            return;
+        }
+
+        let payload = RelayLogPayload {
+            level: record.level().to_string().to_ascii_lowercase(),
+            message: record.args().to_string(),
+            target: Some(record.target().to_string()),
+            file: record.file().map(str::to_string),
+            line: record.line(),
+        };
+
+        enqueue_payload(payload);
+    }
+
+    fn flush(&self) {}
+}
+
+fn enqueue_payload(payload: RelayLogPayload) {
+    RELAY_QUEUE.with(|queue| {
+        queue.borrow_mut().push_back(payload);
+    });
+
+    start_sender_if_needed();
+}
+
+fn start_sender_if_needed() {
+    let should_start = RELAY_SENDING.with(|sending| {
+        if sending.get() {
+            false
+        } else {
+            sending.set(true);
+            true
+        }
+    });
+
+    if !should_start {
+        return;
+    }
+
+    spawn_local(async {
+        loop {
+            let next = RELAY_QUEUE.with(|queue| queue.borrow_mut().pop_front());
+            match next {
+                Some(payload) => send_payload(payload).await,
+                None => {
+                    RELAY_SENDING.with(|sending| sending.set(false));
+                    break;
+                }
+            }
+        }
+    });
+}
+
+async fn send_payload(payload: RelayLogPayload) {
+    let request = match Request::post(WEB_LOG_RELAY_ENDPOINT).json(&payload) {
+        Ok(request) => request,
+        Err(_) => return,
+    };
+
+    let _ = request.send().await;
+}

--- a/web/src/logging.rs
+++ b/web/src/logging.rs
@@ -8,6 +8,7 @@ use serde::Serialize;
 use wasm_bindgen_futures::spawn_local;
 
 const WEB_LOG_RELAY_ENDPOINT: &str = "/_giglog/web-log";
+const MAX_RELAY_QUEUE_LEN: usize = 1024;
 
 #[derive(Debug, Clone, Copy)]
 pub struct WebLoggerConfig {
@@ -80,7 +81,11 @@ impl Log for WebRelayLogger {
 
 fn enqueue_payload(payload: RelayLogPayload) {
     RELAY_QUEUE.with(|queue| {
-        queue.borrow_mut().push_back(payload);
+        let mut queue = queue.borrow_mut();
+        if queue.len() >= MAX_RELAY_QUEUE_LEN {
+            let _ = queue.pop_front();
+        }
+        queue.push_back(payload);
     });
 
     start_sender_if_needed();

--- a/web/src/main.rs
+++ b/web/src/main.rs
@@ -2,12 +2,11 @@ mod logging;
 
 use gig_log_common::logging::{debug, info, is_off};
 use leptos::prelude::*;
-use log::error;
 
 const DEFAULT_WEB_LOG_LEVEL: &str = if cfg!(debug_assertions) {
     "debug"
 } else {
-    "info"
+    "off"
 };
 
 fn init_web_logging() {
@@ -29,10 +28,6 @@ fn init_web_logging() {
 
 fn main() {
     init_web_logging();
-
-    info!("This is an info message");
-    debug!("This is a debug message");
-    error!("this is an error message");
 
     leptos::mount::mount_to_body(|| view! { <h1>"Hello World!"</h1> });
 

--- a/web/src/main.rs
+++ b/web/src/main.rs
@@ -1,5 +1,40 @@
+mod logging;
+
+use gig_log_common::logging::{debug, info, is_off};
 use leptos::prelude::*;
+use log::error;
+
+const DEFAULT_WEB_LOG_LEVEL: &str = if cfg!(debug_assertions) {
+    "debug"
+} else {
+    "info"
+};
+
+fn init_web_logging() {
+    let logger_config = match logging::init_web_logging(DEFAULT_WEB_LOG_LEVEL) {
+        Ok(config) => config,
+        Err(_) => return,
+    };
+
+    if is_off(logger_config.level_filter) {
+        return;
+    }
+
+    info!(
+        "Web logger initialized with WEB_LOG_LEVEL='{}' ({:?})",
+        logger_config.configured_level, logger_config.level_filter
+    );
+    debug!("Mounting GigLog web app");
+}
 
 fn main() {
+    init_web_logging();
+
+    info!("This is an info message");
+    debug!("This is a debug message");
+    error!("this is an error message");
+
     leptos::mount::mount_to_body(|| view! { <h1>"Hello World!"</h1> });
+
+    info!("GigLog web app mounted");
 }


### PR DESCRIPTION
## Summary
- Add a richer API logging stack with shared level parsing, colored verbose/non-verbose formatting, redaction helpers, and HTTP request/response logging controls.
- Add a web-to-dev log relay path by wiring browser log emission to `/_giglog/web-log`, adding a dev-tools relay server, and proxying Trunk traffic so web logs appear in the dev TUI.
- Apply review hardening: default release web logs to off, normalize `LOG_VERBOSE` parsing across services, downgrade expected 4xx/logout paths to warn, and enforce request/response/queue caps to avoid noisy or unbounded logging.

## Testing
- `cargo test -p gig-log-api -p gig-log-common -p gig-log-dev-tools -p gig-log-frontend`
- `cargo test -p gig-log-api`
- `cargo test -p gig-log-frontend`